### PR TITLE
Expand language tour with 13 new pages and fix existing content

### DIFF
--- a/docs/tour/01_hello_world.md
+++ b/docs/tour/01_hello_world.md
@@ -11,7 +11,7 @@ package main
 
 use "fmt"
 
-pub fun main() {
+pub fn main() {
     fmt.println("Hello, World!")
 }
 ```

--- a/docs/tour/02_packages.md
+++ b/docs/tour/02_packages.md
@@ -4,8 +4,19 @@ In Run, packages are a way to organize your code into logical groups.
 
 ## Package main
 
-Programs start it's execution in package main.
+Programs start their execution in package main.
 
-This program is using the packages with import paths "fmt" and "math/rand".
+By convention, the package name is the same as the last element of the import path. For instance, the "math/rand" package comprises files that begin with the statement `package rand`.
 
-By convention, the package name is the same as the last element of the import path. For instance, the "math/rand" package comprises files that begin with the statement package rand.
+```run
+package main
+
+use "fmt"
+use "math/rand"
+
+fn main() {
+    fmt.println("A random number:", rand.intn(100))
+}
+```
+
+Each source file belongs to exactly one package. A directory of `.run` files forms a package — all files in the same directory share the same package name.

--- a/docs/tour/03_types.md
+++ b/docs/tour/03_types.md
@@ -1,14 +1,53 @@
-# Type system
+# Type System
 
 Run has a simple type system with the following built-in types:
 
-- `i64`   - 64-bit signed integer
-- `i32`   - 32-bit signed integer
-- `u64`   - 64-bit unsigned integer
-- `u32`   - 32-bit unsigned integer
-- `f64`   - 64-bit floating point number
-- `f32`   - 32-bit floating point number
-- `bool`  - boolean value, `true` or `false`
-- `string`- UTF-8 encoded string
+## Integer types
+
+- `int`  - platform-sized signed integer
+- `uint` - platform-sized unsigned integer
+- `i32`  - 32-bit signed integer
+- `i64`  - 64-bit signed integer
+- `u32`  - 32-bit unsigned integer
+- `u64`  - 64-bit unsigned integer
+- `byte` - alias for `u8`, a single byte
+
+## Floating point types
+
+- `f32` - 32-bit floating point number
+- `f64` - 64-bit floating point number
+
+## Other types
+
+- `bool` - boolean value, `true` or `false`
+- `str`  - UTF-8 encoded string
 
 ## Type inference
+
+Run can infer the type of a variable from its initial value. You rarely need to write types explicitly when using short declarations.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    x := 42          // int
+    pi := 3.14159    // f64
+    name := "Run"    // str
+    active := true   // bool
+
+    fmt.println(x)
+    fmt.println(pi)
+    fmt.println(name)
+    fmt.println(active)
+}
+```
+
+When you need a specific numeric type, use an explicit type annotation:
+
+```run
+var small: i32 = 100
+var big: u64 = 1_000_000
+var precise: f64 = 0.1
+```

--- a/docs/tour/04_imports.md
+++ b/docs/tour/04_imports.md
@@ -14,7 +14,7 @@ Import paths are the path to the package. They are used to import packages into 
 use "math/rand"
 ```
 
-It is also ca be written as:
+It can also be written as a grouped import:
 
 ```run
 use (

--- a/docs/tour/27_type_conversions.md
+++ b/docs/tour/27_type_conversions.md
@@ -1,0 +1,54 @@
+# Type Conversions
+
+Run requires explicit conversions between types. There are no implicit coercions — even between numeric types of different sizes.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    x := 42           // int
+    y := f64(x)       // convert int to f64
+    z := i32(x)       // convert int to i32
+
+    fmt.println(y)    // 42.0
+    fmt.println(z)    // 42
+}
+```
+
+## Numeric conversions
+
+You can convert between any numeric types using the target type as a function.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    big := 100000
+    small := i32(big)
+
+    ratio := 3.7
+    truncated := int(ratio)  // 3 — truncates toward zero
+
+    fmt.println(small)
+    fmt.println(truncated)
+}
+```
+
+Be aware that converting from a larger type to a smaller one can lose information. Converting a float to an integer truncates the fractional part.
+
+## Newtype conversions
+
+Newtypes require explicit conversion to and from their underlying type:
+
+```run
+newtype Celsius f64
+
+temp := Celsius(100.0)
+raw := f64(temp)       // extract the underlying value
+```
+
+This explicitness prevents subtle bugs from accidental type mixing. If the compiler reports a type mismatch, an explicit conversion makes your intent clear.

--- a/docs/tour/28_operators.md
+++ b/docs/tour/28_operators.md
@@ -1,0 +1,78 @@
+# Operators
+
+Run provides the standard set of operators for arithmetic, comparison, and logic.
+
+## Arithmetic operators
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    a := 10
+    b := 3
+
+    fmt.println(a + b)   // 13  addition
+    fmt.println(a - b)   // 7   subtraction
+    fmt.println(a * b)   // 30  multiplication
+    fmt.println(a / b)   // 3   integer division
+    fmt.println(a % b)   // 1   remainder
+}
+```
+
+Integer division truncates toward zero. Use floating-point types when you need fractional results.
+
+## Comparison operators
+
+Comparisons return a `bool` value.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    x := 5
+    y := 10
+
+    fmt.println(x == y)  // false  equal
+    fmt.println(x != y)  // true   not equal
+    fmt.println(x < y)   // true   less than
+    fmt.println(x > y)   // false  greater than
+    fmt.println(x <= y)  // true   less or equal
+    fmt.println(x >= y)  // false  greater or equal
+}
+```
+
+## Logical operators
+
+Logical operators work on `bool` values and short-circuit.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    a := true
+    b := false
+
+    fmt.println(a and b)  // false
+    fmt.println(a or b)   // true
+    fmt.println(not a)    // false
+}
+```
+
+## Assignment operators
+
+Run supports compound assignment for convenience.
+
+```run
+var x int = 10
+x += 5   // x is now 15
+x -= 3   // x is now 12
+x *= 2   // x is now 24
+x /= 4   // x is now 6
+x %= 5   // x is now 1
+```

--- a/docs/tour/29_break_continue.md
+++ b/docs/tour/29_break_continue.md
@@ -1,0 +1,66 @@
+# Break and Continue
+
+`break` exits a loop immediately. `continue` skips the rest of the current iteration and moves to the next one.
+
+## Break
+
+Use `break` to exit a loop early when a condition is met.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    for i in 0..100 {
+        if i > 4 {
+            break
+        }
+        fmt.println(i)
+    }
+    // prints 0, 1, 2, 3, 4
+}
+```
+
+## Continue
+
+Use `continue` to skip the current iteration.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    for i in 0..10 {
+        if i % 2 == 0 {
+            continue
+        }
+        fmt.println(i)
+    }
+    // prints 1, 3, 5, 7, 9
+}
+```
+
+## Breaking out of nested loops
+
+In nested loops, `break` and `continue` apply to the innermost loop. To break out of an outer loop, use a labeled loop.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    outer: for i in 0..5 {
+        for j in 0..5 {
+            if i + j >= 4 {
+                break :outer
+            }
+            fmt.println(i, j)
+        }
+    }
+}
+```
+
+Labels give you precise control over which loop to break from or continue, avoiding the need for extra boolean flags.

--- a/docs/tour/30_index_iteration.md
+++ b/docs/tour/30_index_iteration.md
@@ -1,0 +1,67 @@
+# Index Iteration
+
+When iterating over a collection, you often need the index alongside the value. Run supports this with a two-variable `for` loop.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    names := ["Alice", "Bob", "Charlie"]
+
+    for i, name in names {
+        fmt.println(i, name)
+    }
+    // 0 Alice
+    // 1 Bob
+    // 2 Charlie
+}
+```
+
+## When to use it
+
+Index iteration is useful when the position of an element matters — for example, when building output, searching for an item's position, or processing parallel collections.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    scores := [85, 92, 78, 95, 88]
+
+    var best_index int = 0
+    var best_score int = scores[0]
+
+    for i, score in scores {
+        if score > best_score {
+            best_score = score
+            best_index = i
+        }
+    }
+
+    fmt.println("highest score:", best_score, "at index", best_index)
+}
+```
+
+## Iterating maps
+
+When iterating over a map, you receive the key and value.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    ages := map[str]int{
+        "Alice": 30,
+        "Bob": 25,
+    }
+
+    for key, value in ages {
+        fmt.println(key, "is", value)
+    }
+}
+```

--- a/docs/tour/31_visibility_modules.md
+++ b/docs/tour/31_visibility_modules.md
@@ -1,0 +1,62 @@
+# Visibility and Modules
+
+Run uses a simple module system: each file is a module and each directory is a package. Visibility is controlled by the `pub` keyword.
+
+## Private by default
+
+Everything in Run is private by default. Only items marked with `pub` are accessible from other packages.
+
+```run
+// math/vector.run
+
+pub struct Vec3 {
+    pub x: f64
+    pub y: f64
+    pub z: f64
+}
+
+// public — callable from other packages
+pub fn Vec3.length(self: @Vec3) f64 {
+    return math.sqrt(self.x*self.x + self.y*self.y + self.z*self.z)
+}
+
+// private — only visible within the math package
+fn normalize_internal(v: &Vec3) {
+    len := v.length()
+    v.x = v.x / len
+    v.y = v.y / len
+    v.z = v.z / len
+}
+```
+
+## Files and packages
+
+A single `.run` file is a module. All files in the same directory belong to the same package and can access each other's private items.
+
+```
+myproject/
+    main.run          // package main
+    math/
+        vector.run    // package math
+        matrix.run    // package math — can see vector.run's private items
+    net/
+        http.run      // package net
+```
+
+## Using packages
+
+Import a package with `use` and access its public items through the package name.
+
+```run
+package main
+
+use "math"
+use "fmt"
+
+fn main() {
+    v := math.Vec3{ x: 1.0, y: 2.0, z: 3.0 }
+    fmt.println(v.length())
+}
+```
+
+This system is deliberately simple. There are no complex visibility modifiers or nested module hierarchies — just `pub` or private, at the package boundary.

--- a/docs/tour/32_error_sets.md
+++ b/docs/tour/32_error_sets.md
@@ -1,0 +1,60 @@
+# Error Sets
+
+When a function returns `!T`, the set of errors it can produce is inferred by the compiler. You do not need to declare error types manually.
+
+## Inferred error sets
+
+The compiler analyzes your function and determines every error that can be returned, including errors propagated with `try`.
+
+```run
+package main
+
+use "fmt"
+use "os"
+
+fn load_config(path: str) !str {
+    file := try os.open(path)      // may return os.NotFound, os.Permission, ...
+    defer file.close()
+    content := try file.read_all() // may return io.ReadError, ...
+    return content
+}
+```
+
+The error set of `load_config` is the union of all errors from `os.open` and `file.read_all`. You never need to write this out — the compiler tracks it for you.
+
+## Handling specific errors
+
+When you need to react differently to specific errors, use `switch` to match on the error variant.
+
+```run
+package main
+
+use "fmt"
+use "os"
+
+fn main() {
+    switch os.open("config.txt") {
+        .ok(file) => {
+            defer file.close()
+            fmt.println("opened successfully")
+        },
+        .err(.not_found) => fmt.println("file not found"),
+        .err(.permission) => fmt.println("access denied"),
+        .err(e) => fmt.println("unexpected error:", e),
+    }
+}
+```
+
+## Propagating errors with `try`
+
+The `try` keyword unwraps a success value or immediately returns the error from the current function. This keeps the happy path clean and readable.
+
+```run
+fn process() !int {
+    data := try read_file("input.txt")   // returns error if read fails
+    parsed := try parse_int(data)         // returns error if parse fails
+    return parsed * 2                     // only reached on success
+}
+```
+
+Errors in Run are values, not exceptions. They flow through the return type, making every error path visible in the function signature.

--- a/docs/tour/33_unsafe.md
+++ b/docs/tour/33_unsafe.md
@@ -1,0 +1,47 @@
+# Unsafe Blocks
+
+Run is safe by default, but sometimes you need to bypass safety checks for performance-critical code. The `unsafe` keyword marks regions where the compiler's safety guarantees are relaxed.
+
+## Shared memory
+
+The primary use of `unsafe` in Run is for shared mutable state between concurrent tasks. Normally, concurrency in Run uses channels for communication. When you need shared memory instead, you must be explicit about it.
+
+```run
+package main
+
+use "fmt"
+use "sync"
+
+fn main() {
+    var counter int = 0
+    var mu sync.Mutex
+
+    for i in 0..10 {
+        run fn() {
+            unsafe {
+                mu.lock()
+                counter = counter + 1
+                mu.unlock()
+            }
+        }
+    }
+
+    // wait for tasks to finish
+    unsafe {
+        mu.lock()
+        fmt.println("counter:", counter)
+        mu.unlock()
+    }
+}
+```
+
+## Why unsafe?
+
+The `unsafe` block serves as documentation and a search target. When something goes wrong with concurrent code, you know exactly where to look. It also signals to other developers that extra care is needed when modifying this section.
+
+## Guidelines
+
+- Keep `unsafe` blocks as small as possible
+- Prefer channels over shared memory when performance allows
+- Always protect shared state with synchronization primitives like `sync.Mutex`
+- Comment why the `unsafe` block is necessary

--- a/docs/tour/34_allocators.md
+++ b/docs/tour/34_allocators.md
@@ -1,0 +1,46 @@
+# Allocators
+
+Run uses a default global allocator for heap allocations. For performance-critical or specialized use cases, functions can accept an optional custom allocator.
+
+## The default allocator
+
+Most code uses the default allocator without thinking about it. Heap allocations — like creating structs with `&T` or growing slices — happen automatically.
+
+```run
+package main
+
+use "fmt"
+
+fn main() {
+    names := ["Alice", "Bob", "Charlie"]  // allocated with the default allocator
+    fmt.println(names[0])
+}
+```
+
+## Custom allocators
+
+When you need control over how memory is allocated — for example, using an arena for batch allocations or a pool for fixed-size objects — you can pass a custom allocator to functions that support it.
+
+```run
+package main
+
+use "fmt"
+use "mem"
+
+fn main() {
+    arena := mem.arena_allocator(1024 * 1024)  // 1 MB arena
+    defer arena.deinit()
+
+    // allocations from the arena are freed all at once
+    data := make_buffer(arena, 256)
+    process(data)
+}
+```
+
+## When to use custom allocators
+
+- **Arena allocators** — for request-scoped or phase-scoped work where all allocations can be freed together
+- **Pool allocators** — for many small, same-sized allocations
+- **Tracking allocators** — for debugging memory usage during development
+
+Most programs never need custom allocators. The default allocator works well for general use. Custom allocators are a tool for optimization once you understand your program's allocation patterns.

--- a/docs/tour/35_testing.md
+++ b/docs/tour/35_testing.md
@@ -1,0 +1,62 @@
+# Testing
+
+Run has a built-in testing framework in the `testing` standard library package. Tests live alongside the code they test.
+
+## Writing tests
+
+A test is a function that takes a `testing.T` parameter. Use `t.expect` to assert conditions.
+
+```run
+package math
+
+use "testing"
+
+fn add(a: int, b: int) int {
+    return a + b
+}
+
+fn test_add(t: &testing.T) {
+    t.expect(add(2, 3) == 5)
+    t.expect(add(-1, 1) == 0)
+    t.expect(add(0, 0) == 0)
+}
+```
+
+## Running tests
+
+Run all tests in your project from the command line:
+
+```
+run test
+```
+
+To run tests in a specific package:
+
+```
+run test math
+```
+
+## Test organization
+
+Tests are typically written in the same file as the code they test. This keeps tests close to the implementation and gives them access to private functions within the package.
+
+```
+math/
+    vector.run        // contains Vec3 and its tests
+    matrix.run        // contains Matrix and its tests
+```
+
+## Failing with a message
+
+Use `t.fail` to report a failure with a descriptive message.
+
+```run
+fn test_divide(t: &testing.T) {
+    result := divide(10, 3)
+    if result != 3 {
+        t.fail("expected 3, got", result)
+    }
+}
+```
+
+Writing tests from the start catches bugs early and gives you confidence to refactor. The `run test` command makes it easy to run them often.

--- a/docs/tour/36_project_structure.md
+++ b/docs/tour/36_project_structure.md
@@ -1,0 +1,66 @@
+# Project Structure
+
+Run follows a simple, conventional directory layout for organizing projects.
+
+## Standard layout
+
+```
+myproject/
+    cmd/
+        myapp/
+            main.run       // command-line entry point
+    pkg/
+        auth/
+            auth.run       // higher-level module: authentication
+        http/
+            server.run     // higher-level module: HTTP server
+    lib/
+        hash/
+            hash.run       // lower-level library: hashing
+        buffer/
+            buffer.run     // lower-level library: buffer utilities
+    README.md
+```
+
+## Directory roles
+
+- **`cmd/`** — Entry points for command-line tools. Each subdirectory is a separate executable with a `main.run` file.
+- **`pkg/`** — Higher-level modules that form the application's core logic. These may depend on `lib/` packages.
+- **`lib/`** — Lower-level, reusable libraries. These should have minimal dependencies and are candidates for sharing across projects.
+
+## Simple projects
+
+Not every project needs this structure. A small program can be a single file:
+
+```
+hello/
+    main.run
+```
+
+As your project grows, introduce directories naturally. Move reusable code into `lib/`, application logic into `pkg/`, and entry points into `cmd/`.
+
+## Package naming
+
+Each directory is a package. The package name matches the directory name:
+
+```run
+// pkg/auth/auth.run
+package auth
+
+pub fn login(user: str, pass: str) !Session {
+    // ...
+}
+```
+
+```run
+// cmd/myapp/main.run
+package main
+
+use "auth"
+
+fn main() {
+    session := try auth.login("admin", "secret")
+}
+```
+
+Keep package names short, lowercase, and descriptive. Avoid generic names like `utils` or `common`.

--- a/docs/tour/37_standard_library.md
+++ b/docs/tour/37_standard_library.md
@@ -1,0 +1,63 @@
+# Standard Library
+
+Run ships with a comprehensive standard library, comparable in scope to Go's. It covers the most common tasks so you can build real applications without third-party dependencies.
+
+## Core packages
+
+| Package    | Description                          |
+|------------|--------------------------------------|
+| `fmt`      | String formatting and printing       |
+| `strings`  | String searching, splitting, joining |
+| `bytes`    | Byte slice utilities                 |
+| `math`     | Mathematical functions and constants |
+| `time`     | Time, durations, and timers          |
+
+## I/O and system
+
+| Package    | Description                          |
+|------------|--------------------------------------|
+| `io`       | Readers, writers, buffered I/O       |
+| `os`       | File system, processes, environment  |
+| `log`      | Structured logging                   |
+
+## Networking
+
+| Package    | Description                          |
+|------------|--------------------------------------|
+| `net`      | TCP/UDP sockets, DNS resolution      |
+| `http`     | HTTP server and client               |
+
+## Data and encoding
+
+| Package    | Description                          |
+|------------|--------------------------------------|
+| `json`     | JSON encoding and decoding           |
+| `crypto`   | Hashing, encryption, TLS            |
+
+## Concurrency and testing
+
+| Package    | Description                          |
+|------------|--------------------------------------|
+| `sync`     | Mutexes, atomics, wait groups        |
+| `testing`  | Built-in test framework              |
+
+## Example: a small HTTP server
+
+```run
+package main
+
+use "http"
+use "fmt"
+
+fn handle(w: &http.ResponseWriter, r: @http.Request) {
+    w.write("Hello from Run!")
+}
+
+fn main() {
+    http.handle_fn("/", handle)
+    fmt.println("listening on :8080")
+    http.listen_and_serve(":8080")
+}
+```
+
+The standard library is designed to be practical and unsurprising. When you need something common — reading a file, serving HTTP, encoding JSON — it is already there.

--- a/docs/tour/38_design_philosophy.md
+++ b/docs/tour/38_design_philosophy.md
@@ -1,0 +1,39 @@
+# Design Philosophy
+
+Run is built on a few deliberate principles. Understanding them helps you write idiomatic code and explains why certain features are absent.
+
+## Simplicity over expressiveness
+
+Run optimizes for readability and a small learning curve. There is one way to loop (`for`), one way to handle errors (`!T` with `try` and `switch`), and one way to define types (`struct`). This means less time debating style and more time solving problems.
+
+## No generics
+
+This is Run's most opinionated decision. Generics add significant complexity to a language — in syntax, error messages, and mental overhead. Run avoids them entirely.
+
+Built-in types that would normally require generics — slices, maps, channels, nullable types, error unions — have language-level support instead.
+
+```run
+// These work without generics — they are built into the language
+names := ["Alice", "Bob"]              // []str
+ages := map[str]int{"Alice": 30}       // map[str]int
+ch := make_chan(int, 10)               // chan int
+var x: int? = 42                       // int?
+fn read() !str { ... }                 // !str
+```
+
+For user-defined types, use traits and concrete implementations. In practice, this covers the vast majority of real-world needs without the complexity tax of generics.
+
+## Memory safety without complexity
+
+Run's generational references provide memory safety without a garbage collector (runtime pauses) or a borrow checker (compile-time complexity). The trade-off is a small runtime cost on pointer dereferences, which is negligible in most applications.
+
+## Explicit over implicit
+
+- Type conversions are explicit — no silent coercions
+- Trait implementations are explicit — no implicit interface satisfaction
+- Error handling is explicit — errors cannot be silently ignored
+- Visibility is explicit — `pub` or private, nothing in between
+
+## Go's pragmatism meets systems control
+
+Run targets developers who like Go's straightforward approach but want more control over memory and performance. If Go is "C with garbage collection," Run is "Go without garbage collection" — keeping the simplicity while giving you deterministic resource management.

--- a/docs/tour/39_whats_next.md
+++ b/docs/tour/39_whats_next.md
@@ -1,0 +1,69 @@
+# What's Next
+
+Congratulations — you have completed the Run language tour! Here is a summary of what you learned and where to go from here.
+
+## What you covered
+
+- **Basics** — variables, constants, types, functions, operators
+- **Control flow** — for loops, if/else, switch, break/continue, defer
+- **Data types** — structs, slices, maps, strings, pointers
+- **Type system** — methods, traits, sum types, nullable types, newtypes
+- **Error handling** — error unions with `!T`, `try`, and `switch`
+- **Closures** — first-class functions and captured variables
+- **Concurrency** — green threads with `run`, channels for communication
+- **Memory model** — generational references, owning and non-owning pointers
+- **Tooling** — testing, project structure, standard library
+
+## A complete example
+
+Here is a small program that ties several concepts together:
+
+```run
+package main
+
+use "fmt"
+use "os"
+
+pub struct Config {
+    host: str
+    port: int
+}
+
+trait Display {
+    fn string(self: @Self) str
+}
+
+impl Display for Config {
+    fn string(self: @Config) str {
+        return fmt.sprintf("%s:%d", self.host, self.port)
+    }
+}
+
+fn load_config(path: str) !Config {
+    content := try os.read_file(path)
+    host := try parse_field(content, "host")
+    port := try parse_int(try parse_field(content, "port"))
+    return Config{ host: host, port: port }
+}
+
+fn main() {
+    switch load_config("server.conf") {
+        .ok(config) => {
+            fmt.println("starting server on", config.string())
+        },
+        .err(e) => {
+            fmt.println("error:", e)
+            os.exit(1)
+        },
+    }
+}
+```
+
+## Next steps
+
+- **Read the specification** — the full language spec covers every detail
+- **Build something** — the best way to learn is to write a real program
+- **Explore the standard library** — `fmt`, `http`, `json`, and more are ready to use
+- **Join the community** — ask questions, share what you build, and help improve Run
+
+Happy coding!


### PR DESCRIPTION
Fix typos and incomplete sections in existing tour files:
- 01_hello_world: fix `fun` -> `fn` keyword
- 02_packages: fix grammar, add code example
- 03_types: complete type inference section, add missing types (int, uint, byte)
- 04_imports: fix typo in grouped import description

Add new tour pages covering spec topics not previously addressed:
- 27: Type conversions (explicit numeric and newtype conversions)
- 28: Operators (arithmetic, comparison, logical, assignment)
- 29: Break and continue (loop control, labeled loops)
- 30: Index iteration (for i, val in collection; map iteration)
- 31: Visibility and modules (pub, file=module, dir=package)
- 32: Error sets (inferred error sets, specific error matching)
- 33: Unsafe blocks (shared memory, synchronization)
- 34: Allocators (default and custom allocators, arenas)
- 35: Testing (testing package, writing and running tests)
- 36: Project structure (standard layout: cmd/, pkg/, lib/)
- 37: Standard library (overview of all 14 stdlib packages)
- 38: Design philosophy (no generics rationale, explicit over implicit)
- 39: What's next (recap, complete example, next steps)

https://claude.ai/code/session_01KDfn7cza9AYDJVs7RGbd3u