### PR TITLE
Remove colons from type annotations in declarations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -39,25 +39,25 @@ const a int = 32    // compile-time constant
 ## Functions
 
 ```
-pub fn add(a: int, b: int) int {
+pub fn add(a int, b int) int {
     return a + b
 }
 
-fn private_helper(x: int) int {
+fn private_helper(x int) int {
     return x * 2
 }
 ```
 
 - Zig-style signature: return type after parameters, no arrow
 - `pub` keyword for public visibility, private by default
-- Full closures supported: `fn(x: int) int { return x + 1 }`
+- Full closures supported: `fn(x int) int { return x + 1 }`
 
 ## Error Handling
 
 Zig-style error unions. A function that can fail returns `!T`:
 
 ```
-fn read_file(path: str) !str {
+fn read_file(path str) !str {
     // returns str on success, error on failure
 }
 
@@ -94,11 +94,11 @@ switch read_file("config.txt") {
 
 ```
 pub struct Point {
-    x: f64
-    y: f64
+    x f64
+    y f64
 }
 
-fn (p: &Point) distance(other: @Point) f64 {
+fn (p &Point) distance(other @Point) f64 {
     dx := p.x - other.x
     dy := p.y - other.y
     return math.sqrt(dx * dx + dy * dy)
@@ -112,11 +112,11 @@ fn (p: &Point) distance(other: @Point) f64 {
 
 ```
 pub trait Stringer {
-    fn (s: @Self) to_string() str
+    fn (s @Self) to_string() str
 }
 
 impl Stringer for Point {
-    fn (p: @Point) to_string() str {
+    fn (p @Point) to_string() str {
         return fmt.sprintf("(%f, %f)", p.x, p.y)
     }
 }
@@ -142,8 +142,8 @@ switch state {
 ### Nullable Types
 
 ```
-var x: int? = null
-var y: int? = 42
+var x int? = null
+var y int? = 42
 
 switch x {
     .some(val) => use(val),
@@ -220,7 +220,7 @@ run fn() { do_work() }
 ### Channels
 
 ```
-var ch: chan int
+var ch chan int
 ch := make_chan(int)        // unbuffered
 ch := make_chan(int, 100)   // buffered
 
@@ -241,7 +241,7 @@ within `unsafe` blocks.
 
 ```
 // math/vector.run
-pub struct Vec3 { x: f64, y: f64, z: f64 }
+pub struct Vec3 { x f64, y f64, z f64 }
 
 // main.run
 import "math"

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -165,8 +165,6 @@ pub const Parser = struct {
         }
         self.advance(); // consume name
 
-        self.expectToken(.colon);
-
         // receiver type
         const type_node = try self.parseType();
 
@@ -204,7 +202,6 @@ pub const Parser = struct {
             return null_node;
         }
         self.advance(); // param name
-        self.expectToken(.colon);
         const type_node = try self.parseType();
         return self.tree.addNode(.{
             .tag = .param,
@@ -260,7 +257,6 @@ pub const Parser = struct {
             return null_node;
         }
         self.advance(); // field name
-        self.expectToken(.colon);
         const type_node = try self.parseType();
 
         // Optional default value
@@ -1385,7 +1381,7 @@ test "parse short variable declaration" {
 }
 
 test "parse function definition" {
-    const source = "pub fn add(a: int, b: int) int {\n    return a + b\n}";
+    const source = "pub fn add(a int, b int) int {\n    return a + b\n}";
     var lexer = Lexer.init(source);
     var tokens = try lexer.tokenize(std.testing.allocator);
     defer tokens.deinit(std.testing.allocator);
@@ -1398,7 +1394,7 @@ test "parse function definition" {
 }
 
 test "parse struct" {
-    const source = "struct Point {\n    x: f64,\n    y: f64\n}";
+    const source = "struct Point {\n    x f64,\n    y f64\n}";
     var lexer = Lexer.init(source);
     var tokens = try lexer.tokenize(std.testing.allocator);
     defer tokens.deinit(std.testing.allocator);
@@ -1424,7 +1420,7 @@ test "parse sum type" {
 }
 
 test "parse method with receiver" {
-    const source = "fn (p: &Point) distance(other: @Point) f64 {\n    return 0.0\n}";
+    const source = "fn (p &Point) distance(other @Point) f64 {\n    return 0.0\n}";
     var lexer = Lexer.init(source);
     var tokens = try lexer.tokenize(std.testing.allocator);
     defer tokens.deinit(std.testing.allocator);


### PR DESCRIPTION
Type annotations in function parameters, method receivers, and struct
fields no longer use a colon separator. This makes the syntax consistent
with variable declarations which already use `var x int` without colons.

Before: fn add(a: int, b: int) int
After:  fn add(a int, b int) int

Struct literal field initialization (name: value) retains the colon
since that separates a field name from a value expression, not a type.

https://claude.ai/code/session_01MtDyFjnEUrSXRX3FD2fQRm