### PR TITLE
Rename string type from 'str' to 'string' across the codebase

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -57,8 +57,8 @@ fn private_helper(x int) int {
 Zig-style error unions. A function that can fail returns `!T`:
 
 ```
-fn read_file(path str) !str {
-    // returns str on success, error on failure
+fn read_file(path string) !string {
+    // returns string on success, error on failure
 }
 
 // Caller handles with try:
@@ -81,7 +81,7 @@ switch read_file("config.txt") {
 - **Integers**: `int`, `uint`, `i32`, `i64`, `u32`, `u64`, `byte`
 - **Floats**: `f32`, `f64`
 - **Boolean**: `bool`
-- **String**: `str` — UTF-8 byte slice
+- **String**: `string` — UTF-8 byte slice
 
 ### Strings
 
@@ -112,11 +112,11 @@ fn (p &Point) distance(other @Point) f64 {
 
 ```
 pub trait Stringer {
-    fn (s @Self) to_string() str
+    fn (s @Self) to_string() string
 }
 
 impl Stringer for Point {
-    fn (p @Point) to_string() str {
+    fn (p @Point) to_string() string {
         return fmt.sprintf("(%f, %f)", p.x, p.y)
     }
 }
@@ -128,7 +128,7 @@ impl Stringer for Point {
 ### Sum Types / Tagged Unions
 
 ```
-type State = .loading | .ready(Data) | .error(str)
+type State = .loading | .ready(Data) | .error(string)
 
 switch state {
     .loading => show_spinner(),
@@ -159,7 +159,7 @@ switch x {
 
 ```
 type UserID = int    // distinct type, not an alias
-type Email = str
+type Email = string
 ```
 
 - Creates a new type that is **not interchangeable** with the underlying type

--- a/docs/tour/03_types.md
+++ b/docs/tour/03_types.md
@@ -20,7 +20,7 @@ Run has a simple type system with the following built-in types:
 ## Other types
 
 - `bool` - boolean value, `true` or `false`
-- `str`  - UTF-8 encoded string
+- `string`  - UTF-8 encoded string
 
 ## Type inference
 
@@ -34,7 +34,7 @@ use "fmt"
 fn main() {
     x := 42          // int
     pi := 3.14159    // f64
-    name := "Run"    // str
+    name := "Run"    // string
     active := true   // bool
 
     fmt.println(x)

--- a/docs/tour/05_variables.md
+++ b/docs/tour/05_variables.md
@@ -10,14 +10,14 @@ Use `var` to declare a variable with an explicit type. Variables declared with `
 var x int        // x is 0
 var y f64        // y is 0.0
 var z bool       // z is false
-var s str        // s is ""
+var s string        // s is ""
 ```
 
 You can also provide an initial value:
 
 ```run
 var x int = 42
-var name str = "Run"
+var name string = "Run"
 ```
 
 ## Short declarations
@@ -48,5 +48,5 @@ Variables declared without an explicit initial value are given their zero value:
 
 - `0` for numeric types
 - `false` for `bool`
-- `""` for `str`
+- `""` for `string`
 - `null` for nullable types

--- a/docs/tour/06_constants.md
+++ b/docs/tour/06_constants.md
@@ -9,7 +9,7 @@ use "fmt"
 
 const pi f64 = 3.14159
 const max_size int = 1024
-const greeting str = "Hello"
+const greeting string = "Hello"
 
 fn main() {
     fmt.println(pi)

--- a/docs/tour/07_functions.md
+++ b/docs/tour/07_functions.md
@@ -36,7 +36,7 @@ fn helper() {
 Functions that do not return a value simply omit the return type.
 
 ```run
-fn greet(name: str) {
+fn greet(name: string) {
     fmt.println("Hello, " + name)
 }
 ```

--- a/docs/tour/10_switch.md
+++ b/docs/tour/10_switch.md
@@ -7,7 +7,7 @@ package main
 
 use "fmt"
 
-fn describe(x: int) str {
+fn describe(x: int) string {
     switch x {
         1 => return "one",
         2 => return "two",

--- a/docs/tour/13_structs.md
+++ b/docs/tour/13_structs.md
@@ -35,9 +35,9 @@ Structs can be made public with `pub`. Field visibility follows the same rules â
 
 ```run
 pub struct Config {
-    pub host: str
+    pub host: string
     pub port: int
-    secret: str  // private to this package
+    secret: string  // private to this package
 }
 ```
 

--- a/docs/tour/15_maps.md
+++ b/docs/tour/15_maps.md
@@ -8,7 +8,7 @@ package main
 use "fmt"
 
 fn main() {
-    ages := map[str]int{
+    ages := map[string]int{
         "Alice": 30,
         "Bob": 25,
     }

--- a/docs/tour/16_strings.md
+++ b/docs/tour/16_strings.md
@@ -1,6 +1,6 @@
 # Strings
 
-Strings in Run are UTF-8 encoded byte sequences. The string type is `str`.
+Strings in Run are UTF-8 encoded byte sequences. The string type is `string`.
 
 ```run
 package main

--- a/docs/tour/18_traits.md
+++ b/docs/tour/18_traits.md
@@ -8,7 +8,7 @@ package main
 use "fmt"
 
 trait Stringer {
-    fn string(self: @Self) str
+    fn string(self: @Self) string
 }
 
 pub struct Point {
@@ -17,7 +17,7 @@ pub struct Point {
 }
 
 impl Stringer for Point {
-    fn string(self: @Point) str {
+    fn string(self: @Point) string {
         return fmt.sprintf("(%f, %f)", self.x, self.y)
     }
 }

--- a/docs/tour/19_sum_types.md
+++ b/docs/tour/19_sum_types.md
@@ -9,7 +9,7 @@ use "fmt"
 
 type Color = .red | .green | .blue | .custom(int)
 
-fn color_name(c: Color) str {
+fn color_name(c: Color) string {
     switch c {
         .red => return "red",
         .green => return "green",
@@ -32,7 +32,7 @@ fn main() {
 When you `switch` on a sum type, the compiler checks that every variant is handled. If you miss a case, the program will not compile. This prevents bugs from unhandled states.
 
 ```run
-type State = .loading | .ready(Data) | .error(str)
+type State = .loading | .ready(Data) | .error(string)
 
 fn handle(s: State) {
     switch s {

--- a/docs/tour/20_nullable_types.md
+++ b/docs/tour/20_nullable_types.md
@@ -7,7 +7,7 @@ package main
 
 use "fmt"
 
-fn find(names: []str, target: str) int? {
+fn find(names: []string, target: string) int? {
     for i, name in names {
         if name == target {
             return i

--- a/docs/tour/22_error_handling.md
+++ b/docs/tour/22_error_handling.md
@@ -8,7 +8,7 @@ package main
 use "fmt"
 use "os"
 
-fn read_config(path: str) !str {
+fn read_config(path: string) !string {
     file := try os.open(path)
     defer file.close()
     return try file.read_all()

--- a/docs/tour/24_concurrency.md
+++ b/docs/tour/24_concurrency.md
@@ -8,7 +8,7 @@ package main
 use "fmt"
 use "time"
 
-fn say(msg: str) {
+fn say(msg: string) {
     for i in 0..3 {
         time.sleep(100)
         fmt.println(msg)

--- a/docs/tour/25_channels.md
+++ b/docs/tour/25_channels.md
@@ -45,6 +45,6 @@ An unbuffered channel synchronizes the sender and receiver — the sender blocks
 A buffered channel allows sends to proceed without blocking until the buffer is full. This is useful when the sender and receiver run at different speeds.
 
 ```run
-ch := make_chan(str, 5)
+ch := make_chan(string, 5)
 ch <- "hello"  // does not block (buffer has space)
 ```

--- a/docs/tour/30_index_iteration.md
+++ b/docs/tour/30_index_iteration.md
@@ -55,7 +55,7 @@ package main
 use "fmt"
 
 fn main() {
-    ages := map[str]int{
+    ages := map[string]int{
         "Alice": 30,
         "Bob": 25,
     }

--- a/docs/tour/32_error_sets.md
+++ b/docs/tour/32_error_sets.md
@@ -12,7 +12,7 @@ package main
 use "fmt"
 use "os"
 
-fn load_config(path: str) !str {
+fn load_config(path: string) !string {
     file := try os.open(path)      // may return os.NotFound, os.Permission, ...
     defer file.close()
     content := try file.read_all() // may return io.ReadError, ...

--- a/docs/tour/36_project_structure.md
+++ b/docs/tour/36_project_structure.md
@@ -47,7 +47,7 @@ Each directory is a package. The package name matches the directory name:
 // pkg/auth/auth.run
 package auth
 
-pub fn login(user: str, pass: str) !Session {
+pub fn login(user: string, pass: string) !Session {
     // ...
 }
 ```

--- a/docs/tour/38_design_philosophy.md
+++ b/docs/tour/38_design_philosophy.md
@@ -14,11 +14,11 @@ Built-in types that would normally require generics — slices, maps, channels, 
 
 ```run
 // These work without generics — they are built into the language
-names := ["Alice", "Bob"]              // []str
-ages := map[str]int{"Alice": 30}       // map[str]int
+names := ["Alice", "Bob"]              // []string
+ages := map[string]int{"Alice": 30}    // map[string]int
 ch := make_chan(int, 10)               // chan int
 var x: int? = 42                       // int?
-fn read() !str { ... }                 // !str
+fn read() !string { ... }             // !string
 ```
 
 For user-defined types, use traits and concrete implementations. In practice, this covers the vast majority of real-world needs without the complexity tax of generics.

--- a/docs/tour/39_whats_next.md
+++ b/docs/tour/39_whats_next.md
@@ -25,21 +25,21 @@ use "fmt"
 use "os"
 
 pub struct Config {
-    host: str
+    host: string
     port: int
 }
 
 trait Display {
-    fn string(self: @Self) str
+    fn string(self: @Self) string
 }
 
 impl Display for Config {
-    fn string(self: @Config) str {
+    fn string(self: @Config) string {
         return fmt.sprintf("%s:%d", self.host, self.port)
     }
 }
 
-fn load_config(path: str) !Config {
+fn load_config(path: string) !Config {
     content := try os.read_file(path)
     host := try parse_field(content, "host")
     port := try parse_int(try parse_field(content, "port"))

--- a/examples/errors.run
+++ b/examples/errors.run
@@ -2,7 +2,7 @@
 import "fmt"
 import "os"
 
-fn read_config(path: str) !str {
+fn read_config(path: string) !string {
     file := try os.open(path)
     defer file.close()
     return try file.read_all()

--- a/examples/structs.run
+++ b/examples/structs.run
@@ -14,11 +14,11 @@ fn (p: &Point) distance(other: @Point) f64 {
 }
 
 pub trait Stringer {
-    fn (s: @Self) to_string() str
+    fn (s: @Self) to_string() string
 }
 
 impl Stringer for Point {
-    fn (p: @Point) to_string() str {
+    fn (p: @Point) to_string() string {
         return fmt.sprintf("(%f, %f)", p.x, p.y)
     }
 }

--- a/examples/sumtypes.run
+++ b/examples/sumtypes.run
@@ -3,7 +3,7 @@ import "fmt"
 
 type Color = .red | .green | .blue | .custom(int)
 
-type Result = .ok(int) | .err(str)
+type Result = .ok(int) | .err(string)
 
 fn divide(a: int, b: int) Result {
     if b == 0 {
@@ -12,7 +12,7 @@ fn divide(a: int, b: int) Result {
     return .ok(a / b)
 }
 
-fn color_name(c: Color) str {
+fn color_name(c: Color) string {
     switch c {
         .red => return "red",
         .green => return "green",

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -223,7 +223,7 @@ pub const Node = struct {
         variant,
 
         // Types (used in type position)
-        /// Simple named type: `int`, `str`, `MyStruct`
+        /// Simple named type: `int`, `string`, `MyStruct`
         type_name,
         /// Pointer type: `&T`
         type_ptr,

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -377,7 +377,7 @@ pub const Parser = struct {
         self.advance(); // type name
         self.expectToken(.equal);
 
-        // Parse sum type variants: .loading | .ready(Data) | .error(str)
+        // Parse sum type variants: .loading | .ready(Data) | .error(string)
         const start: u32 = @intCast(self.tree.extra_data.items.len);
         var count: u32 = 0;
 
@@ -1265,7 +1265,7 @@ pub const Parser = struct {
             });
         }
 
-        // Named type: int, str, MyStruct, etc.
+        // Named type: int, string, MyStruct, etc.
         if (self.peekTag() == .identifier) {
             const tok = self.pos;
             self.advance();
@@ -1407,7 +1407,7 @@ test "parse struct" {
 }
 
 test "parse sum type" {
-    const source = "type State = .loading | .ready(Data) | .error(str)";
+    const source = "type State = .loading | .ready(Data) | .error(string)";
     var lexer = Lexer.init(source);
     var tokens = try lexer.tokenize(std.testing.allocator);
     defer tokens.deinit(std.testing.allocator);


### PR DESCRIPTION
The Run language's string type is now 'string' instead of 'str', providing
a clearer and more descriptive type name consistent with other languages.
Updated all references in spec, docs, examples, and source comments/tests.

https://claude.ai/code/session_01Fhdrd291oxXLpZ1F2pdM8x