### PR TITLE
Make default string iteration yield characters, .bytes for raw bytes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,9 +86,9 @@ switch read_file("config.txt") {
 ### Strings
 
 - UTF-8 encoded byte slices
-- Two iteration modes:
-  - `for b in s.bytes { }` — fast, iterate over raw bytes
-  - `for c in s.chars { }` — slower, iterate over unicode codepoints
+- Default iteration yields characters (unicode codepoints):
+  - `for c in s { }` — iterate over characters
+  - `for b in s.bytes { }` — iterate over raw bytes
 
 ### Structs
 

--- a/docs/tour/16_strings.md
+++ b/docs/tour/16_strings.md
@@ -15,11 +15,21 @@ fn main() {
 
 ## Iteration
 
-Strings support two iteration modes.
+Iterating over a string yields characters (Unicode code points) by default.
+
+### Character iteration (default)
+
+Ranging over a string directly gives you one character per iteration. This handles multi-byte UTF-8 sequences correctly.
+
+```run
+for ch in greeting {
+    fmt.println(ch)
+}
+```
 
 ### Byte iteration
 
-Use `.bytes` to iterate over the raw bytes of a string.
+Use `.bytes` to iterate over the raw bytes of a string instead.
 
 ```run
 for b in greeting.bytes {
@@ -27,14 +37,4 @@ for b in greeting.bytes {
 }
 ```
 
-### Character iteration
-
-Use `.chars` to iterate over Unicode characters (code points).
-
-```run
-for ch in greeting.chars {
-    fmt.println(ch)
-}
-```
-
-Character iteration handles multi-byte UTF-8 sequences correctly, making it the preferred way to process text.
+Byte iteration is faster but does not respect character boundaries — a multi-byte character will appear as multiple separate bytes.


### PR DESCRIPTION
Ranging over a string directly (`for c in s { }`) now yields Unicode
characters by default. Use `.bytes` to iterate over raw bytes instead.
Removes the `.chars` accessor in favor of the simpler default behavior.

https://claude.ai/code/session_01KApku1EXp6whCZLFVPQsK6