### PR TITLE
Replace => (fat_arrow) with :: (colon_colon) for switch arm syntax

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -68,8 +68,8 @@ content := try read_file("config.txt")
 
 // Or with switch:
 switch read_file("config.txt") {
-    .ok(content) => use(content),
-    .err(e) => log(e),
+    .ok(content) :: use(content),
+    .err(e) :: log(e),
 }
 ```
 
@@ -143,9 +143,9 @@ fn (p @Point) to_string() string {
 type State = .loading | .ready(Data) | .error(string)
 
 switch state {
-    .loading => show_spinner(),
-    .ready(data) => render(data),
-    .error(msg) => show_error(msg),
+    .loading :: show_spinner(),
+    .ready(data) :: render(data),
+    .error(msg) :: show_error(msg),
 }
 ```
 
@@ -158,8 +158,8 @@ var x int? = null
 var y int? = 42
 
 switch x {
-    .some(val) => use(val),
-    .null => handle_missing(),
+    .some(val) :: use(val),
+    .null :: handle_missing(),
 }
 ```
 
@@ -194,10 +194,10 @@ for i, item in collection { }   // index + value
 
 ```
 switch value {
-    1 => do_one(),
-    2, 3 => do_two_or_three(),
-    .variant(x) => use(x),
-    _ => default(),
+    1 :: do_one(),
+    2, 3 :: do_two_or_three(),
+    .variant(x) :: use(x),
+    _ :: default(),
 }
 ```
 

--- a/docs/tour/10_switch.md
+++ b/docs/tour/10_switch.md
@@ -9,10 +9,10 @@ use "fmt"
 
 fun describe(x: int) string {
     switch x {
-        1 => return "one",
-        2 => return "two",
-        3 => return "three",
-        _ => return "other",
+        1 :: return "one",
+        2 :: return "two",
+        3 :: return "three",
+        _ :: return "other",
     }
 }
 

--- a/docs/tour/19_sum_types.md
+++ b/docs/tour/19_sum_types.md
@@ -11,10 +11,10 @@ type Color = .red | .green | .blue | .custom(int)
 
 fun color_name(c: Color) string {
     switch c {
-        .red => return "red",
-        .green => return "green",
-        .blue => return "blue",
-        .custom(val) => return fmt.sprintf("custom(%d)", val),
+        .red :: return "red",
+        .green :: return "green",
+        .blue :: return "blue",
+        .custom(val) :: return fmt.sprintf("custom(%d)", val),
     }
 }
 
@@ -36,9 +36,9 @@ type State = .loading | .ready(Data) | .error(string)
 
 fun handle(s: State) {
     switch s {
-        .loading => fmt.println("loading..."),
-        .ready(data) => process(data),
-        .error(msg) => fmt.println(msg),
+        .loading :: fmt.println("loading..."),
+        .ready(data) :: process(data),
+        .error(msg) :: fmt.println(msg),
     }
 }
 ```

--- a/docs/tour/20_nullable_types.md
+++ b/docs/tour/20_nullable_types.md
@@ -20,8 +20,8 @@ fun main() {
     names := ["Alice", "Bob", "Charlie"]
 
     switch find(names, "Bob") {
-        .some(i) => fmt.println("found at index", i),
-        .none => fmt.println("not found"),
+        .some(i) :: fmt.println("found at index", i),
+        .none :: fmt.println("not found"),
     }
 }
 ```
@@ -36,7 +36,7 @@ var x: int? = null
 // x + 1    // error: cannot use nullable value directly
 
 switch x {
-    .some(val) => fmt.println(val + 1),
-    .none => fmt.println("no value"),
+    .some(val) :: fmt.println(val + 1),
+    .none :: fmt.println("no value"),
 }
 ```

--- a/docs/tour/22_error_handling.md
+++ b/docs/tour/22_error_handling.md
@@ -16,8 +16,8 @@ fun read_config(path: string) !string {
 
 fun main() {
     switch read_config("config.txt") {
-        .ok(content) => fmt.println(content),
-        .err(e) => fmt.println("failed to read config"),
+        .ok(content) :: fmt.println(content),
+        .err(e) :: fmt.println("failed to read config"),
     }
 }
 ```
@@ -40,8 +40,8 @@ Use `switch` to handle both success and error cases explicitly.
 
 ```run
 switch do_work() {
-    .ok(val) => use(val),
-    .err(e) => log(e),
+    .ok(val) :: use(val),
+    .err(e) :: log(e),
 }
 ```
 

--- a/docs/tour/32_error_sets.md
+++ b/docs/tour/32_error_sets.md
@@ -34,13 +34,13 @@ use "os"
 
 fun main() {
     switch os.open("config.txt") {
-        .ok(file) => {
+        .ok(file) :: {
             defer file.close()
             fmt.println("opened successfully")
         },
-        .err(.not_found) => fmt.println("file not found"),
-        .err(.permission) => fmt.println("access denied"),
-        .err(e) => fmt.println("unexpected error:", e),
+        .err(.not_found) :: fmt.println("file not found"),
+        .err(.permission) :: fmt.println("access denied"),
+        .err(e) :: fmt.println("unexpected error:", e),
     }
 }
 ```

--- a/docs/tour/39_whats_next.md
+++ b/docs/tour/39_whats_next.md
@@ -50,10 +50,10 @@ fun load_config(path: string) !Config {
 
 fun main() {
     switch load_config("server.conf") {
-        .ok(config) => {
+        .ok(config) :: {
             fmt.println("starting server on", config.string())
         },
-        .err(e) => {
+        .err(e) :: {
             fmt.println("error:", e)
             os.exit(1)
         },

--- a/examples/errors.run
+++ b/examples/errors.run
@@ -10,7 +10,7 @@ fn read_config(path: string) !string {
 
 fn main() {
     switch read_config("config.txt") {
-        .ok(content) => fmt.println(content),
-        .err(e) => fmt.println("failed to read config")
+        .ok(content) :: fmt.println(content),
+        .err(e) :: fmt.println("failed to read config")
     }
 }

--- a/examples/sumtypes.run
+++ b/examples/sumtypes.run
@@ -14,18 +14,18 @@ fn divide(a: int, b: int) Result {
 
 fn color_name(c: Color) string {
     switch c {
-        .red => return "red",
-        .green => return "green",
-        .blue => return "blue",
-        .custom(val) => return fmt.sprintf("custom(%d)", val)
+        .red :: return "red",
+        .green :: return "green",
+        .blue :: return "blue",
+        .custom(val) :: return fmt.sprintf("custom(%d)", val)
     }
 }
 
 fn main() {
     result := divide(10, 3)
     switch result {
-        .ok(val) => fmt.println(val),
-        .err(msg) => fmt.println(msg)
+        .ok(val) :: fmt.println(val),
+        .err(msg) :: fmt.println(msg)
     }
 
     c := Color.custom(0xFF00FF)

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -160,7 +160,7 @@ pub const Node = struct {
         /// `switch expr { arms }`
         /// lhs = expr, rhs = extra_data start for arms
         switch_stmt,
-        /// A single switch arm: `pattern => expr`
+        /// A single switch arm: `pattern :: expr`
         /// lhs = pattern, rhs = body
         switch_arm,
         /// Assignment: `lhs = rhs`

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -234,8 +234,6 @@ pub const Lexer = struct {
             '=' => blk: {
                 if (self.peekNext() == @as(u8, '='))
                     break :blk self.advance2(.equal_equal);
-                if (self.peekNext() == @as(u8, '>'))
-                    break :blk self.advance2(.fat_arrow);
                 break :blk self.advance1(.equal);
             },
             '!' => blk: {
@@ -340,14 +338,13 @@ test "lex string and float" {
 }
 
 test "lex operators" {
-    var lexer = Lexer.init(":= == != <= >= <- => .. ::");
+    var lexer = Lexer.init(":= == != <= >= <- .. ::");
     try std.testing.expectEqual(Tag.colon_equal, lexer.next().tag);
     try std.testing.expectEqual(Tag.equal_equal, lexer.next().tag);
     try std.testing.expectEqual(Tag.bang_equal, lexer.next().tag);
     try std.testing.expectEqual(Tag.less_equal, lexer.next().tag);
     try std.testing.expectEqual(Tag.greater_equal, lexer.next().tag);
     try std.testing.expectEqual(Tag.arrow_left, lexer.next().tag);
-    try std.testing.expectEqual(Tag.fat_arrow, lexer.next().tag);
     try std.testing.expectEqual(Tag.dot_dot, lexer.next().tag);
     try std.testing.expectEqual(Tag.colon_colon, lexer.next().tag);
     try std.testing.expectEqual(Tag.eof, lexer.next().tag);

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -720,7 +720,7 @@ pub const Parser = struct {
     fn parseSwitchArm(self: *Parser) Error!NodeIndex {
         const tok = self.pos;
         const pattern = try self.parseExpr();
-        self.expectToken(.fat_arrow);
+        self.expectToken(.colon_colon);
         self.skipNewlines();
 
         var body: NodeIndex = null_node;

--- a/src/token.zig
+++ b/src/token.zig
@@ -82,7 +82,6 @@ pub const Token = struct {
         colon, // :
         colon_colon, // ::
         question, // ?
-        fat_arrow, // =>
 
         // Special
         newline,


### PR DESCRIPTION
The :: operator is faster to type than =>. Since :: was already lexed as
colon_colon, this removes the fat_arrow token entirely and reuses
colon_colon for switch arm pattern-to-body separation.

Changes:
- Remove fat_arrow token from token.zig
- Remove => scanning from lexer.zig
- Update parser to expect colon_colon in switch arms
- Update all examples, spec, and tour docs

https://claude.ai/code/session_01SUfr2cz6beRJBD9V8p8bSf