### PR TITLE
Add multi-return values via anonymous structs (Zig-style)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -54,6 +54,27 @@ fn private_helper(x int) int {
 - `pub` keyword for public visibility, private by default
 - Full closures supported: `fn(x int) int { return x + 1 }`
 
+### Multiple Return Values
+
+Functions can return multiple values using anonymous structs (Zig-style):
+
+```
+fn divmod(a int, b int) struct { quotient int, remainder int } {
+    return .{ quotient: a / b, remainder: a % b }
+}
+
+// Caller accesses fields on the result:
+result := divmod(10, 3)
+result.quotient   // 3
+result.remainder  // 1
+```
+
+- Anonymous struct types can be used anywhere a type is expected
+- Anonymous struct literals use `.{ field: value }` syntax
+- Fields can be separated by commas or newlines
+- Works with error unions: `fn parse(s string) !struct { value int, rest string }`
+- Works with pointers: `fn make() &struct { x int, y int }`
+
 ## Error Handling
 
 Zig-style error unions. A function that can fail returns `!T`:

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -241,5 +241,13 @@ pub const Node = struct {
         type_chan,
         /// Array type: `[N]T`
         type_array,
+        /// Anonymous struct type: `struct { field1 type1, field2 type2 }`
+        /// lhs = extra_data start for field_decl nodes, rhs = field count
+        type_anon_struct,
+
+        // Anonymous struct literal
+        /// `.{ field1: val1, field2: val2 }`
+        /// lhs = null_node, rhs = extra_data start for field inits
+        anon_struct_literal,
     };
 };


### PR DESCRIPTION
Support returning multiple values from functions using anonymous struct
types and literals. This adds two new AST constructs:
- type_anon_struct: `struct { field1 type1, field2 type2 }` in type position
- anon_struct_literal: `.{ field: value }` in expression position

Works with error unions (!struct{...}), pointers (&struct{...}),
closures, methods with receivers, and newline-separated fields.

https://claude.ai/code/session_01AMRrn7DwT89pQCCuaomZLS