### PR TITLE
Add type declarations: `type Name Type` syntax

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -114,6 +114,9 @@ pub const Node = struct {
         /// `type Name = variants`
         /// lhs = extra_data start for variants, rhs = variant count
         type_alias,
+        /// `type Name Type` — simple type declaration (type alias to another type)
+        /// main_token = kw_type, lhs = type node
+        type_decl,
         /// `import "path"`
         /// main_token points to the string literal
         import_decl,


### PR DESCRIPTION
Support simple type declarations alongside existing sum type aliases.
The parser disambiguates based on whether `=` follows the type name:
- `type Name = .variant | ...` remains a sum type (type_alias)
- `type Name int` is a new type declaration (type_decl)

Both forms work with `pub` modifier for exported types.

https://claude.ai/code/session_0122KnE2XaXnb3sbqehnUzPD