### PR TITLE
Add value receiver support to method declarations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -87,6 +87,7 @@ fn (p &Point) translate(dx f64, dy f64) {
 **Receiver types:**
 - `&T` — read/write pointer receiver. The method can read and modify the struct.
 - `@T` — read-only pointer receiver. Compiler-enforced immutability on the receiver.
+- `T` — value receiver. The method receives a copy of the struct. Useful for small types where copying is cheaper than pointer indirection.
 
 Methods can be made public with `pub`:
 

--- a/docs/tour/17_methods.md
+++ b/docs/tour/17_methods.md
@@ -44,8 +44,9 @@ This is the same pattern as Go's method declarations.
 
 - `@T` — read-only receiver. The method can read but not modify the struct.
 - `&T` — read/write receiver. The method can modify the struct's fields.
+- `T` — value receiver. The method receives a copy of the struct. Useful for small types where copying is cheaper than pointer indirection.
 
-Choose `@T` when the method only observes the value, and `&T` when it needs to mutate.
+Choose `@T` when the method only observes the value, `&T` when it needs to mutate, and `T` when working with small types where a copy is preferred.
 
 ```run
 // Read-only — cannot modify p
@@ -57,6 +58,11 @@ fun (p @Point) length() f64 {
 fun (p &Point) translate(dx f64, dy f64) {
     p.x = p.x + dx
     p.y = p.y + dy
+}
+
+// Value — receives a copy of c
+fun (c Circle) radius() f64 {
+    return c.radius
 }
 ```
 

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -130,9 +130,9 @@ pub const Node = struct {
         /// A function parameter: `name: type`
         /// lhs = type node
         param,
-        /// A method receiver: `(self &Type)` or `(self: @Type)` (Go-style)
+        /// A method receiver: `(self &Type)`, `(self: @Type)`, or `(self Type)` (Go-style)
         /// main_token = receiver name identifier
-        /// lhs = type node
+        /// lhs = type node (type_ptr for &T, type_const_ptr for @T, type_name for value receiver)
         receiver,
 
         // Statements

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -2074,7 +2074,15 @@ test "parse method with value receiver" {
 
     var found_receiver = false;
     for (parser.tree.nodes.items) |node| {
-        if (node.tag == .receiver) found_receiver = true;
+        if (node.tag == .receiver) {
+            found_receiver = true;
+            // Value receiver type should be type_name (not type_ptr or type_const_ptr)
+            const type_node = parser.tree.nodes.items[node.data.lhs];
+            try std.testing.expectEqual(.type_name, type_node.tag);
+            // Verify the type name is "Point"
+            const type_name = tokens.items[type_node.main_token].slice(source);
+            try std.testing.expectEqualStrings("Point", type_name);
+        }
     }
     try std.testing.expect(found_receiver);
 }


### PR DESCRIPTION
The parser already handled value receivers (e.g., `fn (c Circle) radius() f64`)
correctly via parseType(), but this wasn't documented or properly tested.

- Document value receiver `T` alongside `&T` and `@T` in SPEC.md and tour
- Update AST receiver node comment to include value receiver variant
- Strengthen test to verify receiver type is type_name (not a pointer type)

https://claude.ai/code/session_015Zf4whSBtFTec2Q3ueHj6s