### PR TITLE
Add GitHub Actions workflow for Zig build and test

### DIFF
--- a/.github/workflows/zig-ci.yml
+++ b/.github/workflows/zig-ci.yml
@@ -1,0 +1,26 @@
+name: Zig CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build
+        run: zig build
+
+      - name: Test
+        run: zig build test


### PR DESCRIPTION
### Motivation
- Add continuous integration to automatically build and run tests for the Zig codebase using GitHub Actions so changes are validated on push and pull requests.

### Description
- Add `.github/workflows/zig-ci.yml` to run on `push` to `main` and on `pull_request`, set up Zig `0.15.2` via `mlugg/setup-zig@v2`, then run `zig build` and `zig build test`.

### Testing
- Attempted to run `zig build` in the local environment but it failed with `bash: command not found: zig`, so CI will validate builds on GitHub-hosted runners.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81003f354832c9e2d9601f89f81e1)