### PR TITLE
Fix parser for `for ... in ...` loops over string expressions

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -13,6 +13,7 @@ pub const Parser = struct {
     pos: u32,
     source: []const u8,
     tree: Ast,
+    allow_struct_literals: bool,
 
     pub const Error = error{OutOfMemory};
 
@@ -22,6 +23,7 @@ pub const Parser = struct {
             .pos = 0,
             .source = source,
             .tree = Ast.init(allocator, source),
+            .allow_struct_literals = true,
         };
     }
 
@@ -681,6 +683,9 @@ pub const Parser = struct {
         // Check for `in` keyword: `for item in collection { }`
         if (self.peekTag() == .kw_in) {
             self.advance();
+            const prev_allow_struct_literals = self.allow_struct_literals;
+            self.allow_struct_literals = false;
+            defer self.allow_struct_literals = prev_allow_struct_literals;
             const iterable = try self.parseExpr();
             // Store the iteration variable (first) and iterable in extra data
             _ = try self.tree.addExtra(first);
@@ -1026,7 +1031,7 @@ pub const Parser = struct {
                     // Struct literal: Type{ field: val, ... }
                     // Only valid after an identifier (type name) or field access
                     const node_tag = self.tree.nodes.items[node].tag;
-                    if (node_tag == .ident or node_tag == .field_access) {
+                    if (self.allow_struct_literals and (node_tag == .ident or node_tag == .field_access)) {
                         node = try self.parseStructLiteral(node);
                     } else {
                         break;


### PR DESCRIPTION
### Motivation
- Address parser failures where the `{` that begins a `for` loop body is misinterpreted as the start of a `Type{...}` struct literal when the iterable is an identifier or field access, causing tests to fail.
- Restore correct parsing behavior for `for item in iterable { ... }` forms (including `s` and `s.bytes`) without regressing struct-literal parsing elsewhere.

### Description
- Added a parser state flag `allow_struct_literals: bool` to `Parser` with default `true` to control whether `Type{...}`-style struct literals are recognized.
- In `parseFor`, when the `in` branch is taken the parser temporarily sets `allow_struct_literals = false` (with a `defer` restore) while parsing the iterable expression so the loop body `{` cannot be mistaken for a struct literal.
- Updated postfix parsing to only enter `parseStructLiteral` for `.l_brace` when `allow_struct_literals` is `true`, preserving struct-literal parsing in other contexts.

### Testing
- CI previously reported `52/54` tests passed and `2` failures (the two failing tests were `parse for-in string iteration (default characters)` and `parse for-in string.bytes iteration`).
- No automated tests were run locally because `zig` isn't available in this environment (attempting `zig build test` failed with `bash: command not found: zig`).
- The change is targeted to the failing cases and should be validated by running `zig build test` in CI or a local environment with `zig` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a811c6cb0c832ca4cd6a03d36d870f)