### PR TITLE
Add compile-time naming convention validation

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Token = @import("token.zig").Token;
 const Lexer = @import("lexer.zig").Lexer;
 const Parser = @import("parser.zig").Parser;
+const naming = @import("naming.zig");
 
 const usage =
     \\Usage: run [command] [options] <file.run>
@@ -154,6 +155,25 @@ fn cmdBuild(allocator: std.mem.Allocator, path: []const u8, command: []const u8)
     if (parser.tree.errors.items.len > 0) {
         for (parser.tree.errors.items) |err| {
             try stderr.print("error: {s} at offset {d}\n", .{ @tagName(err.tag), err.loc.start });
+        }
+        std.process.exit(1);
+    }
+
+    var naming_violations = try naming.checkNaming(allocator, path, &parser.tree, tokens.items);
+    defer naming_violations.deinit(allocator);
+
+    if (naming_violations.items.len > 0) {
+        for (naming_violations.items) |violation| {
+            const rule = switch (violation.tag) {
+                .type_must_be_upper_camel => "type names must start with an uppercase letter and use CamelCase",
+                .variable_must_be_lower_camel => "variable names must start with a lowercase letter and use camelCase",
+                .file_must_be_lower_snake => "file names must start with a lowercase letter and use snake_case",
+            };
+            if (violation.loc.start == 0 and violation.loc.end == 0) {
+                try stderr.print("error: naming violation: {s}: '{s}' ({s})\n", .{ rule, violation.name, path });
+            } else {
+                try stderr.print("error: naming violation at offset {d}: {s}: '{s}'\n", .{ violation.loc.start, rule, violation.name });
+            }
         }
         std.process.exit(1);
     }

--- a/src/naming.zig
+++ b/src/naming.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+const Ast = @import("ast.zig").Ast;
+const Token = @import("token.zig").Token;
+
+pub const ViolationTag = enum {
+    type_must_be_upper_camel,
+    variable_must_be_lower_camel,
+    file_must_be_lower_snake,
+};
+
+pub const Violation = struct {
+    tag: ViolationTag,
+    loc: Token.Loc,
+    name: []const u8,
+};
+
+pub fn checkNaming(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    tree: *const Ast,
+    tokens: []const Token,
+) !std.ArrayList(Violation) {
+    var violations: std.ArrayList(Violation) = .empty;
+
+    try checkFileName(allocator, path, &violations);
+
+    for (tree.nodes.items) |node| {
+        switch (node.tag) {
+            .struct_decl, .interface_decl => {
+                try checkTypeToken(tree, tokens, node.main_token, &violations);
+            },
+            .type_decl, .type_alias => {
+                try checkTypeToken(tree, tokens, node.main_token + 1, &violations);
+            },
+            .var_decl, .let_decl => {
+                try checkVariableToken(tree, tokens, node.main_token + 1, &violations);
+            },
+            .param, .receiver, .field_decl => {
+                try checkVariableToken(tree, tokens, node.main_token, &violations);
+            },
+            .short_var_decl => {
+                const lhs_index: usize = @intCast(node.data.lhs);
+                if (node.data.lhs != 0 and lhs_index < tree.nodes.items.len) {
+                    const lhs = tree.nodes.items[lhs_index];
+                    if (lhs.tag == .ident) {
+                        try checkVariableToken(tree, tokens, lhs.main_token, &violations);
+                    }
+                }
+            },
+            else => {},
+        }
+    }
+
+    return violations;
+}
+
+fn checkFileName(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    violations: *std.ArrayList(Violation),
+) !void {
+    const file_name = std.fs.path.basename(path);
+    const stem = std.fs.path.stem(file_name);
+    if (!isLowerSnake(stem)) {
+        try violations.append(allocator, .{
+            .tag = .file_must_be_lower_snake,
+            .loc = .{ .start = 0, .end = 0 },
+            .name = stem,
+        });
+    }
+}
+
+fn checkTypeToken(
+    tree: *const Ast,
+    tokens: []const Token,
+    token_index: u32,
+    violations: *std.ArrayList(Violation),
+) !void {
+    const idx: usize = @intCast(token_index);
+    if (idx >= tokens.len) return;
+    const tok = tokens[idx];
+    if (tok.tag != .identifier) return;
+    const name = tok.slice(tree.source);
+    if (!isUpperCamel(name)) {
+        try violations.append(tree.allocator, .{
+            .tag = .type_must_be_upper_camel,
+            .loc = tok.loc,
+            .name = name,
+        });
+    }
+}
+
+fn checkVariableToken(
+    tree: *const Ast,
+    tokens: []const Token,
+    token_index: u32,
+    violations: *std.ArrayList(Violation),
+) !void {
+    const idx: usize = @intCast(token_index);
+    if (idx >= tokens.len) return;
+    const tok = tokens[idx];
+    if (tok.tag != .identifier) return;
+    const name = tok.slice(tree.source);
+    if (!isLowerCamel(name)) {
+        try violations.append(tree.allocator, .{
+            .tag = .variable_must_be_lower_camel,
+            .loc = tok.loc,
+            .name = name,
+        });
+    }
+}
+
+fn isUpperCamel(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (!std.ascii.isUpper(name[0])) return false;
+    for (name[1..]) |ch| {
+        if (ch == '_') return false;
+        if (!std.ascii.isAlphanumeric(ch)) return false;
+    }
+    return true;
+}
+
+fn isLowerCamel(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (!std.ascii.isLower(name[0])) return false;
+    for (name[1..]) |ch| {
+        if (ch == '_') return false;
+        if (!std.ascii.isAlphanumeric(ch)) return false;
+    }
+    return true;
+}
+
+fn isLowerSnake(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (!std.ascii.isLower(name[0])) return false;
+    for (name) |ch| {
+        if (!(std.ascii.isLower(ch) or std.ascii.isDigit(ch) or ch == '_')) return false;
+    }
+    return true;
+}
+
+test "naming helpers" {
+    try std.testing.expect(isUpperCamel("MyType"));
+    try std.testing.expect(!isUpperCamel("myType"));
+    try std.testing.expect(!isUpperCamel("My_Type"));
+
+    try std.testing.expect(isLowerCamel("myVar1"));
+    try std.testing.expect(!isLowerCamel("MyVar"));
+    try std.testing.expect(!isLowerCamel("my_var"));
+
+    try std.testing.expect(isLowerSnake("my_file_name"));
+    try std.testing.expect(!isLowerSnake("My_file"));
+    try std.testing.expect(!isLowerSnake("myFile"));
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,6 +9,7 @@ pub const Ast = @import("ast.zig").Ast;
 pub const Node = @import("ast.zig").Node;
 pub const NodeIndex = @import("ast.zig").NodeIndex;
 pub const Parser = @import("parser.zig").Parser;
+pub const naming = @import("naming.zig");
 
 const std = @import("std");
 


### PR DESCRIPTION
### Motivation
- Enforce repository naming conventions at compile time so source code follows the rules: types must be UpperCamelCase, variables must be lowerCamelCase, and file stems must be lower_snake_case.
- Surface clear diagnostics during `build`/`check`/implicit `run <file.run>` so violations are discovered early in the developer loop.

### Description
- Add `src/naming.zig` which implements `checkNaming(allocator, path, tree, tokens)` and helper predicates `isUpperCamel`, `isLowerCamel`, and `isLowerSnake`, and returns an array of `Violation` records for any rule breaks.
- Integrate the naming check into the compiler pipeline by invoking `naming.checkNaming` from `cmdBuild` in `src/main.zig` after parsing and after parse errors are handled, emitting human-readable diagnostics and exiting non-zero on violations.
- Export the new module from `src/root.zig` as `pub const naming = @import("naming.zig");` so it is part of the public module surface.
- Include unit tests in `src/naming.zig` for the helper predicates (`test "naming helpers"`), and make small adjustments to token/index handling to ensure safe casts when indexing arrays.

### Testing
- Attempted to run `zig fmt src/main.zig src/root.zig src/naming.zig` but `zig` is not installed in the environment, so formatting/compile-time checks were not executed (failed).
- No `zig build test` or `zig build` was run in this environment, so runtime compilation and the added `test` block were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a815809ad8832cae8adecc2f1b10ef)