### PR TITLE
Implement initial fmt.print support and variadic fmt codegen dispatch

### DIFF
--- a/src/codegen_c.zig
+++ b/src/codegen_c.zig
@@ -6,6 +6,7 @@ pub const CCodegen = struct {
     module: *const ir.Module,
     allocator: std.mem.Allocator,
     indent_level: u32,
+    current_func: ?*const ir.Function,
 
     pub fn init(allocator: std.mem.Allocator, module: *const ir.Module) CCodegen {
         return .{
@@ -13,6 +14,7 @@ pub const CCodegen = struct {
             .module = module,
             .allocator = allocator,
             .indent_level = 0,
+            .current_func = null,
         };
     }
 
@@ -69,6 +71,9 @@ pub const CCodegen = struct {
     }
 
     fn emitFunction(self: *CCodegen, func: *const ir.Function) !void {
+        self.current_func = func;
+        defer self.current_func = null;
+
         // Function signature
         try self.emitIndent();
         try self.writer().print("{s} {s}(", .{ func.return_type_name, func.name });
@@ -296,6 +301,34 @@ pub const CCodegen = struct {
                 const call_idx = inst.arg1;
                 if (call_idx < self.module.call_infos.items.len) {
                     const info = self.module.call_infos.items[call_idx];
+                    if (std.mem.eql(u8, info.target_name, "run_fmt_print") or std.mem.eql(u8, info.target_name, "run_fmt_println")) {
+                        for (info.args.items) |arg_ref| {
+                            const arg_type = self.typeNameForRef(arg_ref);
+                            if (std.mem.eql(u8, arg_type, "run_string_t")) {
+                                try self.emitIndent();
+                                try self.writer().print("run_fmt_print(_t{d});\n", .{arg_ref});
+                            } else if (std.mem.eql(u8, arg_type, "int64_t")) {
+                                try self.emitIndent();
+                                try self.writer().print("run_fmt_print_int(_t{d});\n", .{arg_ref});
+                            } else if (std.mem.eql(u8, arg_type, "double")) {
+                                try self.emitIndent();
+                                try self.writer().print("run_fmt_print_float(_t{d});\n", .{arg_ref});
+                            } else if (std.mem.eql(u8, arg_type, "bool")) {
+                                try self.emitIndent();
+                                try self.writer().print("run_fmt_print_bool(_t{d});\n", .{arg_ref});
+                            } else {
+                                try self.emitIndent();
+                                try self.writer().print("/* unsupported fmt arg type: {s} */\n", .{arg_type});
+                            }
+                        }
+
+                        if (std.mem.eql(u8, info.target_name, "run_fmt_println")) {
+                            try self.emitIndent();
+                            try self.writer().print("run_fmt_newline();\n", .{});
+                        }
+                        return;
+                    }
+
                     if (inst.result != ir.null_ref) {
                         try self.writer().print("_t{d} = {s}(", .{ inst.result, info.target_name });
                     } else {
@@ -442,6 +475,22 @@ pub const CCodegen = struct {
         try self.writer().print("\"", .{});
     }
 
+    fn typeNameForRef(self: *const CCodegen, ref: ir.Ref) []const u8 {
+        const func = self.current_func orelse return "void*";
+
+        for (func.params.items) |p| {
+            if (p.ref == ref) return p.type_name;
+        }
+
+        for (func.blocks.items) |*block| {
+            for (block.insts.items) |inst| {
+                if (inst.result == ref) return self.inferCType(inst);
+            }
+        }
+
+        return "void*";
+    }
+
     fn emitIndent(self: *CCodegen) !void {
         var i: u32 = 0;
         while (i < self.indent_level) : (i += 1) {
@@ -535,6 +584,41 @@ test "CCodegen: arithmetic instructions" {
 
     try std.testing.expect(std.mem.indexOf(u8, result, "_t3 = _t1 + _t2;") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "return _t3;") != null);
+}
+
+test "CCodegen: fmt.println prints mixed primitive args" {
+    var module = ir.Module.init();
+    defer module.deinit(std.testing.allocator);
+
+    const fid = try module.addFunction(std.testing.allocator, "run_main__main");
+    var func = module.getFunction(fid);
+    func.return_type_name = "void";
+
+    const b0 = try func.addBlock(std.testing.allocator);
+    var block = func.getBlock(b0);
+
+    const str_idx = try module.addStringConstant(std.testing.allocator, "value=");
+    const t1 = func.allocRef();
+    try block.addInst(std.testing.allocator, ir.makeInst(.const_string, t1, str_idx, 0));
+
+    const t2 = func.allocRef();
+    try block.addInst(std.testing.allocator, ir.makeInst(.const_int, t2, 42, 0));
+
+    const t3 = func.allocRef();
+    try block.addInst(std.testing.allocator, ir.makeInst(.const_bool, t3, 1, 0));
+
+    const call_idx = try module.addCallInfo(std.testing.allocator, "run_fmt_println", &[_]ir.Ref{ t1, t2, t3 });
+    try block.addInst(std.testing.allocator, ir.makeInst(.call, ir.null_ref, call_idx, 0));
+    try block.addInst(std.testing.allocator, ir.makeInst(.ret_void, 0, 0, 0));
+
+    var cg = CCodegen.init(std.testing.allocator, &module);
+    defer cg.deinit();
+
+    const result = try cg.generate();
+    try std.testing.expect(std.mem.indexOf(u8, result, "run_fmt_print(_t1);") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "run_fmt_print_int(_t2);") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "run_fmt_print_bool(_t3);") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "run_fmt_newline();") != null);
 }
 
 test "CCodegen: control flow" {

--- a/src/lower.zig
+++ b/src/lower.zig
@@ -778,6 +778,7 @@ const LoweringContext = struct {
 
     fn isVoidCall(name: []const u8) bool {
         return std.mem.eql(u8, name, "run_fmt_println") or
+            std.mem.eql(u8, name, "run_fmt_print") or
             std.mem.eql(u8, name, "run_fmt_print_int") or
             std.mem.eql(u8, name, "run_fmt_print_float") or
             std.mem.eql(u8, name, "run_fmt_print_bool") or
@@ -786,6 +787,7 @@ const LoweringContext = struct {
 
     fn mapBuiltinCall(name: []const u8) []const u8 {
         if (std.mem.eql(u8, name, "fmt.println")) return "run_fmt_println";
+        if (std.mem.eql(u8, name, "fmt.print")) return "run_fmt_print";
         if (std.mem.eql(u8, name, "fmt.print_int")) return "run_fmt_print_int";
         if (std.mem.eql(u8, name, "fmt.print_float")) return "run_fmt_print_float";
         if (std.mem.eql(u8, name, "fmt.print_bool")) return "run_fmt_print_bool";
@@ -855,6 +857,21 @@ test "lower: hello world" {
     try std.testing.expectEqualStrings("Hello, World!", module.string_constants.items[0].value);
     try std.testing.expectEqual(@as(usize, 1), module.call_infos.items.len);
     try std.testing.expectEqualStrings("run_fmt_println", module.call_infos.items[0].target_name);
+}
+
+test "lower: fmt.print maps to runtime print" {
+    var module = try testLower(
+        \\use "fmt"
+        \\fn main() {
+        \\    fmt.print("a", "b")
+        \\}
+        \\
+    );
+    defer module.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), module.call_infos.items.len);
+    try std.testing.expectEqualStrings("run_fmt_print", module.call_infos.items[0].target_name);
+    try std.testing.expectEqual(@as(usize, 2), module.call_infos.items[0].args.items.len);
 }
 
 test "lower: integer literal" {

--- a/src/runtime/run_fmt.c
+++ b/src/runtime/run_fmt.c
@@ -10,6 +10,16 @@ void run_fmt_println(run_string_t s) {
     putchar('\n');
 }
 
+void run_fmt_print(run_string_t s) {
+    if (s.len > 0) {
+        fwrite(s.ptr, 1, s.len, stdout);
+    }
+}
+
+void run_fmt_newline(void) {
+    putchar('\n');
+}
+
 void run_fmt_print_int(int64_t v) {
     printf("%" PRId64, v);
 }

--- a/src/runtime/run_fmt.h
+++ b/src/runtime/run_fmt.h
@@ -7,6 +7,8 @@
 #include <stdint.h>
 
 void run_fmt_println(run_string_t s);
+void run_fmt_print(run_string_t s);
+void run_fmt_newline(void);
 void run_fmt_print_int(int64_t v);
 void run_fmt_print_float(double v);
 void run_fmt_print_bool(bool v);


### PR DESCRIPTION
### Motivation
- Begin implementing the `fmt` standard library (milestone M4) by plumbing a simple, pragmatic path for multi-argument printing so examples and docs that call `fmt.print` / `fmt.println` work end-to-end. 
- Provide a bootstrap implementation that emits per-argument runtime calls rather than full format-string parsing so the compiler can dogfood printing while `sprintf`/format specifiers are implemented later.

### Description
- Added runtime primitives `run_fmt_print(run_string_t)` and `run_fmt_newline()` and exported them in `src/runtime/run_fmt.h` with implementations in `src/runtime/run_fmt.c` to support printing without/with a trailing newline. 
- Lowering now maps `fmt.print(...)` to the runtime target `run_fmt_print` and treats print targets as void calls in `src/lower.zig`. 
- C codegen (`src/codegen_c.zig`) was extended to detect `run_fmt_print` / `run_fmt_println` call infos and emit per-argument typed print calls (`run_fmt_print`, `run_fmt_print_int`, `run_fmt_print_float`, `run_fmt_print_bool`) followed by `run_fmt_newline()` for `println`, using a new `typeNameForRef` helper and `current_func` tracking. 
- Added unit tests validating the lowering mapping (`src/lower.zig`) and the C codegen emission for mixed primitive `println` arguments (`src/codegen_c.zig`). 

### Testing
- Added Zig test cases in `src/lower.zig` and `src/codegen_c.zig` that assert `fmt.print` lowers to `run_fmt_print` and that `run_fmt_println` emits the expected sequence of typed runtime calls; these tests were committed with the change. 
- Attempted to run the full test suite with `zig build test` but the environment does not have `zig` installed so execution was not possible and the run failed. 
- Repository and unit-test changes were compiled-less validated via added tests and static diffs; runtime behavior will be validated once `zig` is available and `zig build test` is executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b25be8cf20832c80288eefbd5b7442)