### PR TITLE
Add crypto standard library package stubs (Fixes #103)

### DIFF
--- a/stdlib/crypto/aes/aes.run
+++ b/stdlib/crypto/aes/aes.run
@@ -1,0 +1,36 @@
+package aes
+
+use "crypto"
+use "crypto/cipher"
+
+// The AES block size in bytes.
+pub let blockSize = 16
+
+// Block represents an AES cipher block. Implements the cipher.Block interface.
+pub Block struct {
+    implements {
+        cipher.Block
+    }
+
+    key []byte
+}
+
+// newCipher creates and returns a new AES cipher.Block.
+// The key argument should be the AES key, either 16, 24, or 32 bytes
+// to select AES-128, AES-192, or AES-256.
+pub fun newCipher(key []byte) !Block {
+    return Block{ key: alloc([]byte, 0) }
+}
+
+// encrypt encrypts a single block from src into dst.
+pub fun (b @Block) encrypt(dst []byte, src []byte) {
+}
+
+// decrypt decrypts a single block from src into dst.
+pub fun (b @Block) decrypt(dst []byte, src []byte) {
+}
+
+// blockSize returns the AES block size (always 16).
+pub fun (b @Block) blockSize() int {
+    return blockSize
+}

--- a/stdlib/crypto/aes/aes_test.run
+++ b/stdlib/crypto/aes/aes_test.run
@@ -1,0 +1,5 @@
+package aes
+
+use "testing"
+
+// Tests for crypto/aes will go here.

--- a/stdlib/crypto/argon2/argon2.run
+++ b/stdlib/crypto/argon2/argon2.run
@@ -1,0 +1,14 @@
+package argon2
+
+// idKey derives a key using Argon2id (recommended variant).
+// Recommended parameters: time=3, memory=65536 (64 MB), threads=1.
+pub fun idKey(password []byte, salt []byte, time u32, memory u32, threads u8, keyLen u32) []byte {
+    return alloc([]byte, 0)
+}
+
+// key derives a key using Argon2i.
+// Argon2id is preferred in most cases; use this only when data-independent
+// memory access is required.
+pub fun key(password []byte, salt []byte, time u32, memory u32, threads u8, keyLen u32) []byte {
+    return alloc([]byte, 0)
+}

--- a/stdlib/crypto/argon2/argon2_test.run
+++ b/stdlib/crypto/argon2/argon2_test.run
@@ -1,0 +1,5 @@
+package argon2
+
+use "testing"
+
+// Tests for crypto/argon2 will go here.

--- a/stdlib/crypto/blake2b/blake2b.run
+++ b/stdlib/crypto/blake2b/blake2b.run
@@ -1,0 +1,34 @@
+package blake2b
+
+use "crypto"
+
+// Hash sizes in bytes.
+pub let size256 = 32
+pub let size384 = 48
+pub let size512 = 64
+
+// new256 returns a new BLAKE2b-256 crypto.Hash.
+// If key is non-empty, it creates a keyed hash (MAC).
+pub fun new256(key []byte) !crypto.Hash {
+    return null
+}
+
+// new384 returns a new BLAKE2b-384 crypto.Hash.
+pub fun new384(key []byte) !crypto.Hash {
+    return null
+}
+
+// new512 returns a new BLAKE2b-512 crypto.Hash.
+pub fun new512(key []byte) !crypto.Hash {
+    return null
+}
+
+// sum256 returns the BLAKE2b-256 checksum of the data.
+pub fun sum256(data []byte) [32]byte {
+    return [32]byte{}
+}
+
+// sum512 returns the BLAKE2b-512 checksum of the data.
+pub fun sum512(data []byte) [64]byte {
+    return [64]byte{}
+}

--- a/stdlib/crypto/blake2b/blake2b_test.run
+++ b/stdlib/crypto/blake2b/blake2b_test.run
@@ -1,0 +1,5 @@
+package blake2b
+
+use "testing"
+
+// Tests for crypto/blake2b will go here.

--- a/stdlib/crypto/blake3/blake3.run
+++ b/stdlib/crypto/blake3/blake3.run
@@ -1,0 +1,28 @@
+package blake3
+
+use "crypto"
+
+// The default output size of BLAKE3 in bytes.
+pub let size = 32
+
+// new returns a new crypto.Hash computing the BLAKE3 checksum.
+pub fun new() crypto.Hash {
+    return null
+}
+
+// newKeyed returns a new crypto.Hash computing a keyed BLAKE3 hash (MAC).
+// The key must be exactly 32 bytes.
+pub fun newKeyed(key [32]byte) crypto.Hash {
+    return null
+}
+
+// newDeriveKey returns a new crypto.Hash in BLAKE3 key derivation mode.
+// The context string should be unique to the application and purpose.
+pub fun newDeriveKey(context string) crypto.Hash {
+    return null
+}
+
+// sum256 returns the BLAKE3 checksum of the data (32 bytes).
+pub fun sum256(data []byte) [32]byte {
+    return [32]byte{}
+}

--- a/stdlib/crypto/blake3/blake3_test.run
+++ b/stdlib/crypto/blake3/blake3_test.run
@@ -1,0 +1,5 @@
+package blake3
+
+use "testing"
+
+// Tests for crypto/blake3 will go here.

--- a/stdlib/crypto/chacha20/chacha20.run
+++ b/stdlib/crypto/chacha20/chacha20.run
@@ -1,0 +1,33 @@
+package chacha20
+
+// Key and nonce sizes in bytes.
+pub let keySize = 32
+pub let nonceSize = 12
+pub let nonceSizeX = 24
+
+// Cipher implements ChaCha20/XChaCha20 encryption.
+pub Cipher struct {
+    key   []byte
+    nonce []byte
+}
+
+// newUnauthenticated returns a ChaCha20 stream cipher.
+// Note: This cipher does not provide authentication. For authenticated
+// encryption, use crypto/chacha20poly1305 instead.
+pub fun newUnauthenticated(key []byte, nonce []byte) !Cipher {
+    return Cipher{ key: alloc([]byte, 0), nonce: alloc([]byte, 0) }
+}
+
+// newXUnauthenticated returns an XChaCha20 stream cipher with a 24-byte nonce.
+pub fun newXUnauthenticated(key []byte, nonce []byte) !Cipher {
+    return Cipher{ key: alloc([]byte, 0), nonce: alloc([]byte, 0) }
+}
+
+// xorKeyStream XORs each byte in src with a byte from the ChaCha20 key stream,
+// writing the result into dst.
+pub fun (c &Cipher) xorKeyStream(dst []byte, src []byte) {
+}
+
+// setCounter sets the block counter for the cipher.
+pub fun (c &Cipher) setCounter(counter u32) {
+}

--- a/stdlib/crypto/chacha20/chacha20_test.run
+++ b/stdlib/crypto/chacha20/chacha20_test.run
@@ -1,0 +1,5 @@
+package chacha20
+
+use "testing"
+
+// Tests for crypto/chacha20 will go here.

--- a/stdlib/crypto/chacha20poly1305/chacha20poly1305.run
+++ b/stdlib/crypto/chacha20poly1305/chacha20poly1305.run
@@ -1,0 +1,26 @@
+package chacha20poly1305
+
+use "crypto"
+
+// Key size in bytes.
+pub let keySize = 32
+
+// Nonce size for ChaCha20-Poly1305 in bytes.
+pub let nonceSize = 12
+
+// Nonce size for XChaCha20-Poly1305 in bytes.
+pub let nonceSizeX = 24
+
+// Authentication tag overhead in bytes.
+pub let overhead = 16
+
+// new returns a ChaCha20-Poly1305 AEAD that uses the given 256-bit key.
+pub fun new(key []byte) !crypto.AEAD {
+    return null
+}
+
+// newX returns an XChaCha20-Poly1305 AEAD that uses the given 256-bit key.
+// XChaCha20-Poly1305 uses a 24-byte nonce, making random nonce generation safe.
+pub fun newX(key []byte) !crypto.AEAD {
+    return null
+}

--- a/stdlib/crypto/chacha20poly1305/chacha20poly1305_test.run
+++ b/stdlib/crypto/chacha20poly1305/chacha20poly1305_test.run
@@ -1,0 +1,5 @@
+package chacha20poly1305
+
+use "testing"
+
+// Tests for crypto/chacha20poly1305 will go here.

--- a/stdlib/crypto/cipher/cipher.run
+++ b/stdlib/crypto/cipher/cipher.run
@@ -1,0 +1,73 @@
+package cipher
+
+use "crypto"
+
+// Block represents a cipher operating in a given key's block size.
+pub Block interface {
+    // blockSize returns the cipher's block size.
+    blockSize() int
+
+    // encrypt encrypts the first block in src into dst.
+    encrypt(dst []byte, src []byte)
+
+    // decrypt decrypts the first block in src into dst.
+    decrypt(dst []byte, src []byte)
+}
+
+// Stream represents a stream cipher.
+pub Stream interface {
+    // xorKeyStream XORs each byte in src with a byte from the cipher's
+    // key stream, writing the result to dst.
+    xorKeyStream(dst []byte, src []byte)
+}
+
+// BlockMode represents a block cipher running in a block-based mode (CBC, etc.).
+pub BlockMode interface {
+    // blockSize returns the mode's block size.
+    blockSize() int
+
+    // cryptBlocks encrypts or decrypts a number of blocks.
+    cryptBlocks(dst []byte, src []byte)
+}
+
+// newGCM returns an AEAD wrapping the given cipher in Galois Counter Mode.
+pub fun newGCM(block Block) !crypto.AEAD {
+    return null
+}
+
+// newGCMWithNonceSize returns an AEAD with a non-standard nonce size.
+pub fun newGCMWithNonceSize(block Block, size int) !crypto.AEAD {
+    return null
+}
+
+// newCTR returns a Stream that encrypts/decrypts using the given Block
+// in counter mode.
+pub fun newCTR(block Block, iv []byte) Stream {
+    return null
+}
+
+// newCBCEncrypter returns a BlockMode which encrypts in cipher block chaining mode.
+pub fun newCBCEncrypter(block Block, iv []byte) BlockMode {
+    return null
+}
+
+// newCBCDecrypter returns a BlockMode which decrypts in cipher block chaining mode.
+pub fun newCBCDecrypter(block Block, iv []byte) BlockMode {
+    return null
+}
+
+// newOFB returns a Stream that encrypts/decrypts using the given Block
+// in output feedback mode.
+pub fun newOFB(block Block, iv []byte) Stream {
+    return null
+}
+
+// newCFBEncrypter returns a Stream which encrypts in cipher feedback mode.
+pub fun newCFBEncrypter(block Block, iv []byte) Stream {
+    return null
+}
+
+// newCFBDecrypter returns a Stream which decrypts in cipher feedback mode.
+pub fun newCFBDecrypter(block Block, iv []byte) Stream {
+    return null
+}

--- a/stdlib/crypto/cipher/cipher_test.run
+++ b/stdlib/crypto/cipher/cipher_test.run
@@ -1,0 +1,5 @@
+package cipher
+
+use "testing"
+
+// Tests for crypto/cipher will go here.

--- a/stdlib/crypto/crypto.run
+++ b/stdlib/crypto/crypto.run
@@ -1,0 +1,77 @@
+package crypto
+
+// Hash is the interface for cryptographic hash functions.
+pub Hash interface {
+    // write adds data to the running hash.
+    write(data []byte) !int
+
+    // sum appends the current hash to buf and returns the resulting slice.
+    sum(buf []byte) []byte
+
+    // reset resets the hash to its initial state.
+    reset()
+
+    // size returns the number of bytes sum will produce.
+    size() int
+
+    // blockSize returns the hash's underlying block size.
+    blockSize() int
+}
+
+// AEAD is the interface for authenticated encryption with associated data.
+pub AEAD interface {
+    // seal encrypts and authenticates plaintext, authenticates the
+    // additional data, and appends the result to dst.
+    seal(dst []byte, nonce []byte, plaintext []byte, additionalData []byte) []byte
+
+    // open decrypts and authenticates ciphertext, authenticates the
+    // additional data, and appends the result to dst.
+    open(dst []byte, nonce []byte, ciphertext []byte, additionalData []byte) ![]byte
+
+    // nonceSize returns the size of the nonce that must be passed to seal and open.
+    nonceSize() int
+
+    // overhead returns the maximum difference between the lengths of a
+    // plaintext and its ciphertext.
+    overhead() int
+}
+
+// Signer is the interface for opaque private keys that can sign messages.
+pub Signer interface {
+    // sign signs the message and returns the signature.
+    sign(message []byte) ![]byte
+
+    // publicKey returns the public key corresponding to the signer.
+    publicKey() PublicKey
+}
+
+// Verifier is the interface for verifying digital signatures.
+pub Verifier interface {
+    // verify reports whether sig is a valid signature of message.
+    verify(message []byte, signature []byte) !bool
+}
+
+// PublicKey is a marker interface for public keys.
+pub PublicKey interface {
+    // bytes returns the raw bytes of the public key.
+    bytes() []byte
+}
+
+// PrivateKey is a marker interface for private keys.
+pub PrivateKey interface {
+    // bytes returns the raw bytes of the private key.
+    bytes() []byte
+
+    // public returns the public key corresponding to this private key.
+    public() PublicKey
+}
+
+// CryptoError represents errors from cryptographic operations.
+pub type CryptoError = .invalidKey
+    | .invalidKeyLength
+    | .invalidSignature
+    | .invalidCiphertext
+    | .authenticationFailed
+    | .shortBuffer
+    | .randomFailure
+    | .invalidParameter

--- a/stdlib/crypto/crypto_test.run
+++ b/stdlib/crypto/crypto_test.run
@@ -1,0 +1,5 @@
+package crypto
+
+use "testing"
+
+// Tests for crypto core interfaces will go here.

--- a/stdlib/crypto/ecdh/ecdh.run
+++ b/stdlib/crypto/ecdh/ecdh.run
@@ -1,0 +1,63 @@
+package ecdh
+
+use "crypto"
+
+// Curve identifies an elliptic curve for ECDH.
+pub type Curve = .p256
+    | .p384
+    | .x25519
+
+// PublicKey is an ECDH public key.
+pub PublicKey struct {
+    implements {
+        crypto.PublicKey
+    }
+
+    curve Curve
+    data  []byte
+}
+
+// PrivateKey is an ECDH private key.
+pub PrivateKey struct {
+    implements {
+        crypto.PrivateKey
+    }
+
+    curve     Curve
+    data      []byte
+    publicKey PublicKey
+}
+
+// generateKey generates a new ECDH private key for the given curve.
+pub fun generateKey(curve Curve) !PrivateKey {
+    return PrivateKey{
+        curve: curve,
+        data: alloc([]byte, 0),
+        publicKey: PublicKey{ curve: curve, data: alloc([]byte, 0) },
+    }
+}
+
+// ecdh performs an ECDH exchange and returns the shared secret.
+pub fun (priv @PrivateKey) ecdh(peerPublicKey @PublicKey) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// publicKey returns the public key for this private key.
+pub fun (priv @PrivateKey) publicKey() PublicKey {
+    return priv.publicKey
+}
+
+// public returns the public key as a crypto.PublicKey.
+pub fun (priv @PrivateKey) public() crypto.PublicKey {
+    return priv.publicKey
+}
+
+// bytes returns the raw bytes of the public key.
+pub fun (pub @PublicKey) bytes() []byte {
+    return pub.data
+}
+
+// bytes returns the raw bytes of the private key.
+pub fun (priv @PrivateKey) bytes() []byte {
+    return priv.data
+}

--- a/stdlib/crypto/ecdh/ecdh_test.run
+++ b/stdlib/crypto/ecdh/ecdh_test.run
@@ -1,0 +1,5 @@
+package ecdh
+
+use "testing"
+
+// Tests for crypto/ecdh will go here.

--- a/stdlib/crypto/ecdsa/ecdsa.run
+++ b/stdlib/crypto/ecdsa/ecdsa.run
@@ -1,0 +1,63 @@
+package ecdsa
+
+use "crypto"
+
+// Curve identifies an elliptic curve.
+pub type Curve = .p256
+    | .p384
+
+// PublicKey is an ECDSA public key.
+pub PublicKey struct {
+    implements {
+        crypto.PublicKey
+    }
+
+    curve Curve
+    x     []byte
+    y     []byte
+}
+
+// PrivateKey is an ECDSA private key.
+pub PrivateKey struct {
+    implements {
+        crypto.PrivateKey
+        crypto.Signer
+    }
+
+    publicKey PublicKey
+    d         []byte
+}
+
+// generateKey generates a new ECDSA private key for the given curve.
+pub fun generateKey(curve Curve) !PrivateKey {
+    return PrivateKey{
+        publicKey: PublicKey{ curve: curve, x: alloc([]byte, 0), y: alloc([]byte, 0) },
+        d: alloc([]byte, 0),
+    }
+}
+
+// signASN1 signs a hash (not the message) using the private key,
+// returning the ASN.1-encoded signature.
+pub fun signASN1(privateKey @PrivateKey, hash []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// verifyASN1 verifies the ASN.1-encoded signature of a hash using the public key.
+pub fun verifyASN1(publicKey @PublicKey, hash []byte, sig []byte) bool {
+    return false
+}
+
+// public returns the public key for this private key.
+pub fun (priv @PrivateKey) public() PublicKey {
+    return priv.publicKey
+}
+
+// bytes returns the raw bytes of the public key.
+pub fun (pub @PublicKey) bytes() []byte {
+    return alloc([]byte, 0)
+}
+
+// bytes returns the raw bytes of the private key.
+pub fun (priv @PrivateKey) bytes() []byte {
+    return priv.d
+}

--- a/stdlib/crypto/ecdsa/ecdsa_test.run
+++ b/stdlib/crypto/ecdsa/ecdsa_test.run
@@ -1,0 +1,5 @@
+package ecdsa
+
+use "testing"
+
+// Tests for crypto/ecdsa will go here.

--- a/stdlib/crypto/ed25519/ed25519.run
+++ b/stdlib/crypto/ed25519/ed25519.run
@@ -1,0 +1,68 @@
+package ed25519
+
+use "crypto"
+
+// Key and signature sizes in bytes.
+pub let publicKeySize = 32
+pub let privateKeySize = 64
+pub let signatureSize = 64
+pub let seedSize = 32
+
+// PublicKey is an Ed25519 public key (32 bytes).
+pub PublicKey struct {
+    implements {
+        crypto.PublicKey
+    }
+
+    data []byte
+}
+
+// PrivateKey is an Ed25519 private key (64 bytes, contains seed + public key).
+pub PrivateKey struct {
+    implements {
+        crypto.PrivateKey
+        crypto.Signer
+    }
+
+    data []byte
+}
+
+// generateKey generates a random Ed25519 key pair.
+pub fun generateKey() !(PublicKey, PrivateKey) {
+    return (PublicKey{ data: alloc([]byte, 0) }, PrivateKey{ data: alloc([]byte, 0) })
+}
+
+// newKeyFromSeed creates a private key from a 32-byte seed.
+pub fun newKeyFromSeed(seed []byte) !PrivateKey {
+    return PrivateKey{ data: alloc([]byte, 0) }
+}
+
+// sign signs the message with privateKey and returns a 64-byte signature.
+pub fun sign(privateKey @PrivateKey, message []byte) []byte {
+    return alloc([]byte, 0)
+}
+
+// verify reports whether sig is a valid Ed25519 signature of message by publicKey.
+pub fun verify(publicKey @PublicKey, message []byte, sig []byte) bool {
+    return false
+}
+
+// seed returns the private key seed (first 32 bytes).
+pub fun (priv @PrivateKey) seed() []byte {
+    return alloc([]byte, 0)
+}
+
+// public returns the public key corresponding to priv.
+pub fun (priv @PrivateKey) public() PublicKey {
+    return PublicKey{ data: alloc([]byte, 0) }
+}
+
+// bytes returns the raw bytes of the public key.
+pub fun (pub @PublicKey) bytes() []byte {
+    return pub.data
+}
+
+// bytes returns the raw bytes of the private key.
+pub fun (priv @PrivateKey) bytes() []byte {
+    return priv.data
+}

--- a/stdlib/crypto/ed25519/ed25519_test.run
+++ b/stdlib/crypto/ed25519/ed25519_test.run
@@ -1,0 +1,5 @@
+package ed25519
+
+use "testing"
+
+// Tests for crypto/ed25519 will go here.

--- a/stdlib/crypto/hkdf/hkdf.run
+++ b/stdlib/crypto/hkdf/hkdf.run
@@ -1,0 +1,20 @@
+package hkdf
+
+use "crypto"
+use "io"
+
+// new returns an io.Reader from which keys can be read, using the given hash,
+// secret, optional salt, and optional context info, as described in RFC 5869.
+pub fun new(hashFn fun() crypto.Hash, secret []byte, salt []byte, info []byte) io.Reader {
+    return null
+}
+
+// extract performs the extract step of HKDF, returning the pseudorandom key.
+pub fun extract(hashFn fun() crypto.Hash, secret []byte, salt []byte) []byte {
+    return alloc([]byte, 0)
+}
+
+// expand performs the expand step of HKDF, returning a key of the given length.
+pub fun expand(hashFn fun() crypto.Hash, pseudoRandomKey []byte, info []byte, keyLen int) ![]byte {
+    return alloc([]byte, 0)
+}

--- a/stdlib/crypto/hkdf/hkdf_test.run
+++ b/stdlib/crypto/hkdf/hkdf_test.run
@@ -1,0 +1,5 @@
+package hkdf
+
+use "testing"
+
+// Tests for crypto/hkdf will go here.

--- a/stdlib/crypto/hmac/hmac.run
+++ b/stdlib/crypto/hmac/hmac.run
@@ -1,0 +1,14 @@
+package hmac
+
+use "crypto"
+
+// new returns a crypto.Hash computing an HMAC with the given hash function
+// and key. The hash function must return a new Hash each time it is called.
+pub fun new(hashFn fun() crypto.Hash, key []byte) crypto.Hash {
+    return null
+}
+
+// equal compares two MACs for equality without leaking timing information.
+pub fun equal(mac1 []byte, mac2 []byte) bool {
+    return false
+}

--- a/stdlib/crypto/hmac/hmac_test.run
+++ b/stdlib/crypto/hmac/hmac_test.run
@@ -1,0 +1,5 @@
+package hmac
+
+use "testing"
+
+// Tests for crypto/hmac will go here.

--- a/stdlib/crypto/jwk/jwk.run
+++ b/stdlib/crypto/jwk/jwk.run
@@ -1,0 +1,93 @@
+package jwk
+
+use "crypto"
+
+// KeyType identifies the cryptographic algorithm family of the key.
+pub type KeyType = .rsa
+    | .ec
+    | .octetSequence
+    | .okp
+
+// KeyUse identifies the intended use of the key.
+pub type KeyUse = .signature
+    | .encryption
+
+// Key represents a JSON Web Key per RFC 7517.
+pub Key struct {
+    kty KeyType
+    kid string
+    use KeyUse
+    alg string
+    raw []byte
+}
+
+// KeySet represents a JWK Set (JWKS) per RFC 7517.
+pub KeySet struct {
+    keys []Key
+}
+
+// JwkError represents JWK-related errors.
+pub type JwkError = .malformedKey
+    | .malformedKeySet
+    | .keyNotFound
+    | .unsupportedKeyType
+    | .fetchFailed
+
+// parseKey parses a single JWK from JSON bytes.
+pub fun parseKey(data []byte) !Key {
+    return Key{
+        kid: "",
+        alg: "",
+        raw: alloc([]byte, 0),
+    }
+}
+
+// parseKeySet parses a JWKS from JSON bytes.
+pub fun parseKeySet(data []byte) !KeySet {
+    return KeySet{ keys: alloc([]Key, 0) }
+}
+
+// findKey finds a key in the set by key ID (kid).
+// Returns null if no key with the given ID exists.
+pub fun (ks @KeySet) findKey(kid string) Key? {
+    return null
+}
+
+// fetchKeySet fetches a JWKS from the given URL (e.g., an OAuth provider's
+// /.well-known/jwks.json endpoint).
+pub fun fetchKeySet(url string) !KeySet {
+    return KeySet{ keys: alloc([]Key, 0) }
+}
+
+// toPublicKey converts a JWK to a crypto.PublicKey.
+pub fun (k @Key) toPublicKey() !crypto.PublicKey {
+    return null
+}
+
+// fromPublicKey creates a JWK from a crypto.PublicKey.
+pub fun fromPublicKey(key crypto.PublicKey, kid string) !Key {
+    return Key{
+        kid: kid,
+        alg: "",
+        raw: alloc([]byte, 0),
+    }
+}
+
+// fromPrivateKey creates a JWK from a crypto.PrivateKey (includes private material).
+pub fun fromPrivateKey(key crypto.PrivateKey, kid string) !Key {
+    return Key{
+        kid: kid,
+        alg: "",
+        raw: alloc([]byte, 0),
+    }
+}
+
+// toJSON serializes a Key to JSON bytes.
+pub fun (k @Key) toJSON() ![]byte {
+    return alloc([]byte, 0)
+}
+
+// toJSON serializes a KeySet to JSON bytes.
+pub fun (ks @KeySet) toJSON() ![]byte {
+    return alloc([]byte, 0)
+}

--- a/stdlib/crypto/jwk/jwk_test.run
+++ b/stdlib/crypto/jwk/jwk_test.run
@@ -1,0 +1,5 @@
+package jwk
+
+use "testing"
+
+// Tests for crypto/jwk will go here.

--- a/stdlib/crypto/jwt/jwt.run
+++ b/stdlib/crypto/jwt/jwt.run
@@ -1,0 +1,97 @@
+package jwt
+
+use "crypto"
+use "time"
+
+// SigningMethod identifies the algorithm used to sign the token.
+pub type SigningMethod = .hs256
+    | .hs384
+    | .hs512
+    | .rs256
+    | .rs384
+    | .rs512
+    | .es256
+    | .es384
+    | .edDSA
+
+// Header represents the JWT header (JOSE header).
+pub Header struct {
+    alg string
+    typ string
+    kid string
+}
+
+// RegisteredClaims contains the standard JWT claims per RFC 7519.
+pub RegisteredClaims struct {
+    issuer    string      // iss
+    subject   string      // sub
+    audience  []string    // aud
+    expiresAt time.Time   // exp
+    notBefore time.Time   // nbf
+    issuedAt  time.Time   // iat
+    id        string      // jti
+}
+
+// Token represents a parsed or created JWT.
+pub Token struct {
+    header    Header
+    claims    RegisteredClaims
+    raw       string
+    signature []byte
+    valid     bool
+}
+
+// JwtError represents JWT-related errors.
+pub type JwtError = .malformedToken
+    | .expiredToken
+    | .tokenNotYetValid
+    | .invalidSignature
+    | .invalidClaims
+    | .unsupportedAlgorithm
+    | .invalidKey
+
+// sign creates a signed JWT string from the given claims and signing method.
+pub fun sign(claims RegisteredClaims, method SigningMethod, key []byte) !string {
+    return ""
+}
+
+// signWithKey creates a signed JWT string using a crypto.PrivateKey.
+pub fun signWithKey(claims RegisteredClaims, method SigningMethod, key crypto.PrivateKey) !string {
+    return ""
+}
+
+// parse parses a JWT string and validates its signature using the provided key.
+pub fun parse(tokenString string, key []byte) !Token {
+    return Token{
+        header: Header{ alg: "", typ: "JWT", kid: "" },
+        claims: RegisteredClaims{
+            issuer: "",
+            subject: "",
+            audience: alloc([]string, 0),
+            id: "",
+        },
+        raw: "",
+        signature: alloc([]byte, 0),
+        valid: false,
+    }
+}
+
+// parseWithKey parses a JWT and validates using a crypto.PublicKey.
+pub fun parseWithKey(tokenString string, key crypto.PublicKey) !Token {
+    return parse(tokenString, alloc([]byte, 0))
+}
+
+// parseUnverified parses a JWT without validating the signature.
+// Useful for reading the header (e.g., to find the kid) before verification.
+pub fun parseUnverified(tokenString string) !Token {
+    return parse(tokenString, alloc([]byte, 0))
+}
+
+// validate checks whether the token claims are valid (expiry, nbf, etc.).
+pub fun (t @Token) validate() !void {
+}
+
+// isExpired reports whether the token has expired.
+pub fun (t @Token) isExpired() bool {
+    return false
+}

--- a/stdlib/crypto/jwt/jwt_test.run
+++ b/stdlib/crypto/jwt/jwt_test.run
@@ -1,0 +1,5 @@
+package jwt
+
+use "testing"
+
+// Tests for crypto/jwt will go here.

--- a/stdlib/crypto/md5/md5.run
+++ b/stdlib/crypto/md5/md5.run
@@ -1,0 +1,27 @@
+package md5
+
+use "crypto"
+
+// DEPRECATED: MD5 is cryptographically broken and should not be used
+// for security purposes. Collision attacks are trivial. Use crypto/sha256
+// or crypto/sha3 instead. This package is provided only for legacy
+// compatibility (e.g., verifying old checksums, content fingerprinting
+// where security is not a concern).
+
+// The size of an MD5 checksum in bytes.
+pub let size = 16
+
+// The block size of MD5 in bytes.
+pub let blockSize = 64
+
+// new returns a new crypto.Hash computing the MD5 checksum.
+// DEPRECATED: Use crypto/sha256.new() instead.
+pub fun new() crypto.Hash {
+    return null
+}
+
+// sum returns the MD5 checksum of the data.
+// DEPRECATED: Use crypto/sha256.sum256() instead.
+pub fun sum(data []byte) [16]byte {
+    return [16]byte{}
+}

--- a/stdlib/crypto/md5/md5_test.run
+++ b/stdlib/crypto/md5/md5_test.run
@@ -1,0 +1,5 @@
+package md5
+
+use "testing"
+
+// Tests for crypto/md5 will go here.

--- a/stdlib/crypto/pbkdf2/pbkdf2.run
+++ b/stdlib/crypto/pbkdf2/pbkdf2.run
@@ -1,0 +1,10 @@
+package pbkdf2
+
+use "crypto"
+
+// key derives a key from the password, salt, and iteration count,
+// using the given hash function. Use at least 600,000 iterations
+// with HMAC-SHA-256 for password hashing.
+pub fun key(password []byte, salt []byte, iter int, keyLen int, hashFn fun() crypto.Hash) []byte {
+    return alloc([]byte, 0)
+}

--- a/stdlib/crypto/pbkdf2/pbkdf2_test.run
+++ b/stdlib/crypto/pbkdf2/pbkdf2_test.run
@@ -1,0 +1,5 @@
+package pbkdf2
+
+use "testing"
+
+// Tests for crypto/pbkdf2 will go here.

--- a/stdlib/crypto/rand/rand.run
+++ b/stdlib/crypto/rand/rand.run
@@ -1,0 +1,17 @@
+package rand
+
+// read fills buf with cryptographically secure random bytes.
+// Returns the number of bytes read.
+pub fun read(buf []byte) !int {
+    return 0
+}
+
+// bytes returns n cryptographically secure random bytes.
+pub fun bytes(n int) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// int returns a uniform random int in the range [0, max).
+pub fun int(max int) !int {
+    return 0
+}

--- a/stdlib/crypto/rand/rand_test.run
+++ b/stdlib/crypto/rand/rand_test.run
@@ -1,0 +1,5 @@
+package rand
+
+use "testing"
+
+// Tests for crypto/rand will go here.

--- a/stdlib/crypto/rsa/rsa.run
+++ b/stdlib/crypto/rsa/rsa.run
@@ -1,0 +1,82 @@
+package rsa
+
+use "crypto"
+
+// PublicKey represents an RSA public key.
+pub PublicKey struct {
+    implements {
+        crypto.PublicKey
+    }
+
+    n []byte  // modulus
+    e int     // public exponent
+}
+
+// PrivateKey represents an RSA private key.
+pub PrivateKey struct {
+    implements {
+        crypto.PrivateKey
+        crypto.Signer
+    }
+
+    publicKey PublicKey
+    d         []byte  // private exponent
+    primes    [][]byte
+}
+
+// PSSOptions contains options for PSS signing and verification.
+pub PSSOptions struct {
+    saltLength int
+}
+
+// generateKey generates a new RSA private key of the given bit size.
+pub fun generateKey(bits int) !PrivateKey {
+    return PrivateKey{
+        publicKey: PublicKey{ n: alloc([]byte, 0), e: 65537 },
+        d: alloc([]byte, 0),
+        primes: alloc([][]byte, 0),
+    }
+}
+
+// encryptOAEP encrypts plaintext using RSA-OAEP.
+pub fun encryptOAEP(hash crypto.Hash, pub @PublicKey, msg []byte, label []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// decryptOAEP decrypts ciphertext using RSA-OAEP.
+pub fun decryptOAEP(hash crypto.Hash, priv @PrivateKey, ciphertext []byte, label []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// signPKCS1v15 signs hashed using RSASSA-PKCS1-V1_5-SIGN.
+pub fun signPKCS1v15(priv @PrivateKey, hash crypto.Hash, hashed []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// verifyPKCS1v15 verifies an RSASSA-PKCS1-V1_5-SIGN signature.
+pub fun verifyPKCS1v15(pub @PublicKey, hash crypto.Hash, hashed []byte, sig []byte) !void {
+}
+
+// signPSS signs hashed using RSASSA-PSS.
+pub fun signPSS(priv @PrivateKey, hash crypto.Hash, hashed []byte, opts @PSSOptions) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// verifyPSS verifies an RSASSA-PSS signature.
+pub fun verifyPSS(pub @PublicKey, hash crypto.Hash, hashed []byte, sig []byte, opts @PSSOptions) !void {
+}
+
+// public returns the public key for this private key.
+pub fun (priv @PrivateKey) public() PublicKey {
+    return priv.publicKey
+}
+
+// bytes returns the raw bytes of the public key.
+pub fun (pub @PublicKey) bytes() []byte {
+    return pub.n
+}
+
+// bytes returns the raw bytes of the private key.
+pub fun (priv @PrivateKey) bytes() []byte {
+    return priv.d
+}

--- a/stdlib/crypto/rsa/rsa_test.run
+++ b/stdlib/crypto/rsa/rsa_test.run
@@ -1,0 +1,5 @@
+package rsa
+
+use "testing"
+
+// Tests for crypto/rsa will go here.

--- a/stdlib/crypto/scrypt/scrypt.run
+++ b/stdlib/crypto/scrypt/scrypt.run
@@ -1,0 +1,8 @@
+package scrypt
+
+// key derives a key using the scrypt key derivation function.
+// Parameters n, r, p control CPU/memory cost. n must be a power of 2.
+// Recommended: n=32768, r=8, p=1.
+pub fun key(password []byte, salt []byte, n int, r int, p int, keyLen int) ![]byte {
+    return alloc([]byte, 0)
+}

--- a/stdlib/crypto/scrypt/scrypt_test.run
+++ b/stdlib/crypto/scrypt/scrypt_test.run
@@ -1,0 +1,5 @@
+package scrypt
+
+use "testing"
+
+// Tests for crypto/scrypt will go here.

--- a/stdlib/crypto/sha1/sha1.run
+++ b/stdlib/crypto/sha1/sha1.run
@@ -1,0 +1,26 @@
+package sha1
+
+use "crypto"
+
+// DEPRECATED: SHA-1 is cryptographically broken and should not be used
+// for security purposes. Use crypto/sha256 or crypto/sha3 instead.
+// This package is provided only for legacy compatibility (e.g., verifying
+// old checksums or protocol compatibility where SHA-1 is mandated).
+
+// The size of a SHA-1 checksum in bytes.
+pub let size = 20
+
+// The block size of SHA-1 in bytes.
+pub let blockSize = 64
+
+// new returns a new crypto.Hash computing the SHA-1 checksum.
+// DEPRECATED: Use crypto/sha256.new() instead.
+pub fun new() crypto.Hash {
+    return null
+}
+
+// sum returns the SHA-1 checksum of the data.
+// DEPRECATED: Use crypto/sha256.sum256() instead.
+pub fun sum(data []byte) [20]byte {
+    return [20]byte{}
+}

--- a/stdlib/crypto/sha1/sha1_test.run
+++ b/stdlib/crypto/sha1/sha1_test.run
@@ -1,0 +1,5 @@
+package sha1
+
+use "testing"
+
+// Tests for crypto/sha1 will go here.

--- a/stdlib/crypto/sha256/sha256.run
+++ b/stdlib/crypto/sha256/sha256.run
@@ -1,0 +1,32 @@
+package sha256
+
+use "crypto"
+
+// The size of a SHA-256 checksum in bytes.
+pub let size = 32
+
+// The size of a SHA-224 checksum in bytes.
+pub let size224 = 28
+
+// The block size of SHA-256 and SHA-224 in bytes.
+pub let blockSize = 64
+
+// new returns a new crypto.Hash computing the SHA-256 checksum.
+pub fun new() crypto.Hash {
+    return null
+}
+
+// new224 returns a new crypto.Hash computing the SHA-224 checksum.
+pub fun new224() crypto.Hash {
+    return null
+}
+
+// sum256 returns the SHA-256 checksum of the data.
+pub fun sum256(data []byte) [32]byte {
+    return [32]byte{}
+}
+
+// sum224 returns the SHA-224 checksum of the data.
+pub fun sum224(data []byte) [28]byte {
+    return [28]byte{}
+}

--- a/stdlib/crypto/sha256/sha256_test.run
+++ b/stdlib/crypto/sha256/sha256_test.run
@@ -1,0 +1,5 @@
+package sha256
+
+use "testing"
+
+// Tests for crypto/sha256 will go here.

--- a/stdlib/crypto/sha3/sha3.run
+++ b/stdlib/crypto/sha3/sha3.run
@@ -1,0 +1,45 @@
+package sha3
+
+use "crypto"
+
+// new256 returns a new crypto.Hash computing the SHA3-256 checksum.
+pub fun new256() crypto.Hash {
+    return null
+}
+
+// new512 returns a new crypto.Hash computing the SHA3-512 checksum.
+pub fun new512() crypto.Hash {
+    return null
+}
+
+// ShakeHash is the interface for SHAKE extendable-output functions.
+pub ShakeHash interface {
+    // write absorbs more data into the hash state.
+    write(data []byte) !int
+
+    // read reads output from the hash; it can be called repeatedly.
+    read(buf []byte) !int
+
+    // reset resets the hash to its initial state.
+    reset()
+}
+
+// newShake128 returns a new SHAKE128 variable-output-length hash function.
+pub fun newShake128() ShakeHash {
+    return null
+}
+
+// newShake256 returns a new SHAKE256 variable-output-length hash function.
+pub fun newShake256() ShakeHash {
+    return null
+}
+
+// sum256 returns the SHA3-256 checksum of the data.
+pub fun sum256(data []byte) [32]byte {
+    return [32]byte{}
+}
+
+// sum512 returns the SHA3-512 checksum of the data.
+pub fun sum512(data []byte) [64]byte {
+    return [64]byte{}
+}

--- a/stdlib/crypto/sha3/sha3_test.run
+++ b/stdlib/crypto/sha3/sha3_test.run
@@ -1,0 +1,5 @@
+package sha3
+
+use "testing"
+
+// Tests for crypto/sha3 will go here.

--- a/stdlib/crypto/sha512/sha512.run
+++ b/stdlib/crypto/sha512/sha512.run
@@ -1,0 +1,48 @@
+package sha512
+
+use "crypto"
+
+// The size of a SHA-512 checksum in bytes.
+pub let size = 64
+
+// The size of a SHA-384 checksum in bytes.
+pub let size384 = 48
+
+// The size of a SHA-512/256 checksum in bytes.
+pub let size256 = 32
+
+// The size of a SHA-512/224 checksum in bytes.
+pub let size224 = 28
+
+// The block size of SHA-512 and SHA-384 in bytes.
+pub let blockSize = 128
+
+// new returns a new crypto.Hash computing the SHA-512 checksum.
+pub fun new() crypto.Hash {
+    return null
+}
+
+// new384 returns a new crypto.Hash computing the SHA-384 checksum.
+pub fun new384() crypto.Hash {
+    return null
+}
+
+// new512_256 returns a new crypto.Hash computing the SHA-512/256 checksum.
+pub fun new512_256() crypto.Hash {
+    return null
+}
+
+// new512_224 returns a new crypto.Hash computing the SHA-512/224 checksum.
+pub fun new512_224() crypto.Hash {
+    return null
+}
+
+// sum512 returns the SHA-512 checksum of the data.
+pub fun sum512(data []byte) [64]byte {
+    return [64]byte{}
+}
+
+// sum384 returns the SHA-384 checksum of the data.
+pub fun sum384(data []byte) [48]byte {
+    return [48]byte{}
+}

--- a/stdlib/crypto/sha512/sha512_test.run
+++ b/stdlib/crypto/sha512/sha512_test.run
@@ -1,0 +1,5 @@
+package sha512
+
+use "testing"
+
+// Tests for crypto/sha512 will go here.

--- a/stdlib/crypto/subtle/subtle.run
+++ b/stdlib/crypto/subtle/subtle.run
@@ -1,0 +1,31 @@
+package subtle
+
+// constantTimeCompare returns true if and only if the two slices x and y
+// have equal contents. The time taken is a function of the length of the
+// slices and is independent of the contents.
+pub fun constantTimeCompare(x []byte, y []byte) bool {
+    return false
+}
+
+// constantTimeSelect returns x if v == 1 and y if v == 0.
+// Its behavior is undefined if v takes any other value.
+pub fun constantTimeSelect(v int, x int, y int) int {
+    return 0
+}
+
+// constantTimeByteEq returns 1 if x == y and 0 otherwise.
+pub fun constantTimeByteEq(x byte, y byte) int {
+    return 0
+}
+
+// constantTimeLessOrEq returns 1 if x <= y and 0 otherwise.
+// Its behavior is undefined if x or y are negative.
+pub fun constantTimeLessOrEq(x int, y int) int {
+    return 0
+}
+
+// constantTimeCopy copies the contents of y into x if v == 1.
+// If v == 0, x is left unchanged. Its behavior is undefined
+// if v takes any other value.
+pub fun constantTimeCopy(v int, x []byte, y []byte) {
+}

--- a/stdlib/crypto/subtle/subtle_test.run
+++ b/stdlib/crypto/subtle/subtle_test.run
@@ -1,0 +1,5 @@
+package subtle
+
+use "testing"
+
+// Tests for crypto/subtle will go here.

--- a/stdlib/crypto/tls/tls.run
+++ b/stdlib/crypto/tls/tls.run
@@ -1,0 +1,75 @@
+package tls
+
+use "crypto"
+use "crypto/x509"
+use "io"
+use "net"
+
+// TLS version constants.
+pub let versionTLS12 = 0x0303
+pub let versionTLS13 = 0x0304
+
+// Config holds TLS configuration.
+pub Config struct {
+    certificates   []Certificate
+    rootCAs        @x509.CertPool
+    serverName     string
+    minVersion     int
+    maxVersion     int
+    insecureSkipVerify bool
+}
+
+// Certificate represents a TLS certificate with its private key.
+pub Certificate struct {
+    cert []x509.Certificate
+    key  crypto.PrivateKey
+}
+
+// Conn represents a TLS connection. Implements io.Reader and io.Writer.
+pub Conn struct {
+    implements {
+        io.Reader
+        io.Writer
+        io.Closer
+    }
+
+    inner net.Conn
+}
+
+// TlsError represents TLS-related errors.
+pub type TlsError = .handshakeFailed
+    | .certificateRequired
+    | .certificateRejected
+    | .protocolVersionMismatch
+    | .alertCloseNotify
+    | .alertUnexpectedMessage
+
+// dial creates a TLS connection to the given network address.
+pub fun dial(network string, addr string, config @Config) !Conn {
+    return Conn{}
+}
+
+// read reads data from the TLS connection.
+pub fun (c &Conn) read(buf []byte) !int {
+    return 0
+}
+
+// write writes data to the TLS connection.
+pub fun (c &Conn) write(buf []byte) !int {
+    return 0
+}
+
+// close closes the TLS connection.
+pub fun (c &Conn) close() !void {
+}
+
+// handshake performs the TLS handshake if it hasn't been done yet.
+pub fun (c &Conn) handshake() !void {
+}
+
+// loadX509KeyPair reads and parses a certificate and private key from PEM files.
+pub fun loadX509KeyPair(certFile string, keyFile string) !Certificate {
+    return Certificate{
+        cert: alloc([]x509.Certificate, 0),
+    }
+}

--- a/stdlib/crypto/tls/tls_test.run
+++ b/stdlib/crypto/tls/tls_test.run
@@ -1,0 +1,5 @@
+package tls
+
+use "testing"
+
+// Tests for crypto/tls will go here.

--- a/stdlib/crypto/x25519/x25519.run
+++ b/stdlib/crypto/x25519/x25519.run
@@ -1,0 +1,40 @@
+package x25519
+
+// Point and scalar sizes in bytes.
+pub let pointSize = 32
+pub let scalarSize = 32
+
+// PublicKey is an X25519 public key (32 bytes).
+pub PublicKey struct {
+    data []byte
+}
+
+// PrivateKey is an X25519 private key (32 bytes).
+pub PrivateKey struct {
+    data []byte
+}
+
+// generateKey generates a random X25519 key pair.
+pub fun generateKey() !(PublicKey, PrivateKey) {
+    return (PublicKey{ data: alloc([]byte, 0) }, PrivateKey{ data: alloc([]byte, 0) })
+}
+
+// scalarMult computes the scalar multiplication of scalar and point.
+pub fun scalarMult(scalar []byte, point []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// scalarBaseMult computes the scalar multiplication of scalar and the base point.
+pub fun scalarBaseMult(scalar []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// ecdh performs an X25519 key exchange and returns the shared secret.
+pub fun (priv @PrivateKey) ecdh(peerPublicKey @PublicKey) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// publicKey returns the public key for this private key.
+pub fun (priv @PrivateKey) publicKey() PublicKey {
+    return PublicKey{ data: alloc([]byte, 0) }
+}

--- a/stdlib/crypto/x25519/x25519_test.run
+++ b/stdlib/crypto/x25519/x25519_test.run
@@ -1,0 +1,5 @@
+package x25519
+
+use "testing"
+
+// Tests for crypto/x25519 will go here.

--- a/stdlib/crypto/x509/x509.run
+++ b/stdlib/crypto/x509/x509.run
@@ -1,0 +1,98 @@
+package x509
+
+use "crypto"
+use "time"
+
+// Certificate represents an X.509 certificate.
+pub Certificate struct {
+    raw               []byte
+    rawSubject        []byte
+    rawIssuer         []byte
+    subject           Name
+    issuer            Name
+    notBefore         time.Time
+    notAfter          time.Time
+    serialNumber      []byte
+    publicKey         crypto.PublicKey
+    signatureAlgorithm SignatureAlgorithm
+    isCA              bool
+    dnsNames          []string
+    emailAddresses    []string
+}
+
+// Name represents an X.509 distinguished name.
+pub Name struct {
+    commonName         string
+    organization       []string
+    organizationalUnit []string
+    country            []string
+}
+
+// SignatureAlgorithm identifies a signature algorithm.
+pub type SignatureAlgorithm = .sha256WithRSA
+    | .sha384WithRSA
+    | .sha512WithRSA
+    | .ecdsaWithSHA256
+    | .ecdsaWithSHA384
+    | .ecdsaWithSHA512
+    | .purEd25519
+
+// CertPool is a set of certificates used as trust anchors.
+pub CertPool struct {
+    certs []Certificate
+}
+
+// VerifyOptions contains parameters for certificate verification.
+pub VerifyOptions struct {
+    roots         @CertPool
+    intermediates @CertPool
+    dnsName       string
+    currentTime   time.Time
+}
+
+// CertError represents certificate-related errors.
+pub type CertError = .malformedCertificate
+    | .expiredCertificate
+    | .untrustedRoot
+    | .invalidSignature
+    | .nameNotAllowed
+    | .incompatibleUsage
+
+// parseCertificate parses a single DER-encoded certificate.
+pub fun parseCertificate(der []byte) !Certificate {
+    return Certificate{
+        raw: alloc([]byte, 0),
+        rawSubject: alloc([]byte, 0),
+        rawIssuer: alloc([]byte, 0),
+        subject: Name{ commonName: "", organization: alloc([]string, 0), organizationalUnit: alloc([]string, 0), country: alloc([]string, 0) },
+        issuer: Name{ commonName: "", organization: alloc([]string, 0), organizationalUnit: alloc([]string, 0), country: alloc([]string, 0) },
+        serialNumber: alloc([]byte, 0),
+        isCA: false,
+        dnsNames: alloc([]string, 0),
+        emailAddresses: alloc([]string, 0),
+    }
+}
+
+// parseCertificatePEM parses a PEM-encoded certificate.
+pub fun parseCertificatePEM(pem []byte) !Certificate {
+    return parseCertificate(alloc([]byte, 0))
+}
+
+// verify verifies the certificate against the given options.
+pub fun (cert @Certificate) verify(opts VerifyOptions) !bool {
+    return false
+}
+
+// newCertPool returns a new, empty CertPool.
+pub fun newCertPool() CertPool {
+    return CertPool{ certs: alloc([]Certificate, 0) }
+}
+
+// addCert adds a certificate to the pool.
+pub fun (pool &CertPool) addCert(cert Certificate) {
+}
+
+// systemCertPool returns the system certificate pool.
+pub fun systemCertPool() !CertPool {
+    return CertPool{ certs: alloc([]Certificate, 0) }
+}

--- a/stdlib/crypto/x509/x509_test.run
+++ b/stdlib/crypto/x509/x509_test.run
@@ -1,0 +1,5 @@
+package x509
+
+use "testing"
+
+// Tests for crypto/x509 will go here.


### PR DESCRIPTION
Add the complete crypto package directory structure with stub API files
for 27 sub-packages covering:

- Core: interfaces (Hash, AEAD, Signer, Verifier), error types
- Hashing: sha256, sha512, sha3, blake2b, blake3, hmac
- Symmetric: aes, cipher (modes), chacha20, chacha20poly1305
- Asymmetric: ed25519, x25519, ecdsa, ecdh, rsa
- KDFs: hkdf, pbkdf2, argon2, scrypt
- Auth: jwt (RFC 7519), jwk/jwks (RFC 7517)
- PKI: x509, tls
- Utilities: rand, subtle (constant-time ops)
- Legacy (deprecated): sha1, md5

API design ported from Go crypto/* and x/crypto packages, adapted to
Run syntax with error unions, interfaces, and sum types.

https://claude.ai/code/session_01CJXde6JHS597FWQGgnwiBe