### PR TITLE
stdlib: expand io, fmt, os, strings and add bytes package

### DIFF
--- a/stdlib/bytes/bytes.run
+++ b/stdlib/bytes/bytes.run
@@ -1,0 +1,114 @@
+package bytes
+
+use "io"
+
+// Buffer is a growable byte buffer that implements io.Reader and io.Writer.
+pub Buffer struct {
+    implements {
+        io.Reader
+        io.Writer
+    }
+
+    buf []byte
+    pos int
+}
+
+// read reads from the buffer into buf. Returns the number of bytes read.
+pub fun (b &Buffer) read(buf []byte) !int {
+    return 0
+}
+
+// write appends data to the buffer. Returns the number of bytes written.
+pub fun (b &Buffer) write(data []byte) !int {
+    return 0
+}
+
+// write_string appends the contents of s to the buffer.
+pub fun (b &Buffer) write_string(s string) !int {
+    return 0
+}
+
+// write_byte appends a single byte to the buffer.
+pub fun (b &Buffer) write_byte(c byte) !void {
+}
+
+// bytes returns the unread portion of the buffer as a byte slice.
+pub fun (b @Buffer) bytes() []byte {
+    return alloc([]byte, 0)
+}
+
+// string returns the unread portion of the buffer as a string.
+pub fun (b @Buffer) string() string {
+    return ""
+}
+
+// reset resets the buffer to be empty.
+pub fun (b &Buffer) reset() {
+}
+
+// len returns the number of unread bytes in the buffer.
+pub fun (b @Buffer) len() int {
+    return 0
+}
+
+// cap returns the capacity of the buffer's underlying byte slice.
+pub fun (b @Buffer) cap() int {
+    return 0
+}
+
+// contains reports whether sub is within b.
+pub fun contains(b []byte, sub []byte) bool {
+    return false
+}
+
+// index returns the index of the first instance of sub in b,
+// or null if sub is not present.
+pub fun index(b []byte, sub []byte) int? {
+    return null
+}
+
+// split slices b into all subslices separated by sep.
+pub fun split(b []byte, sep []byte) [][]byte {
+    return alloc([][]byte, 0)
+}
+
+// join concatenates the elements of parts with sep between each element.
+pub fun join(parts [][]byte, sep []byte) []byte {
+    return alloc([]byte, 0)
+}
+
+// trim returns b with leading and trailing whitespace removed.
+pub fun trim(b []byte) []byte {
+    return alloc([]byte, 0)
+}
+
+// equal reports whether a and b are the same length and contain
+// the same bytes.
+pub fun equal(a []byte, b []byte) bool {
+    return false
+}
+
+// has_prefix reports whether b begins with prefix.
+pub fun has_prefix(b []byte, prefix []byte) bool {
+    return false
+}
+
+// has_suffix reports whether b ends with suffix.
+pub fun has_suffix(b []byte, suffix []byte) bool {
+    return false
+}
+
+// repeat returns a new byte slice consisting of count copies of b.
+pub fun repeat(b []byte, count int) []byte {
+    return alloc([]byte, 0)
+}
+
+// to_lower returns a copy of b with all ASCII letters mapped to lower case.
+pub fun to_lower(b []byte) []byte {
+    return alloc([]byte, 0)
+}
+
+// to_upper returns a copy of b with all ASCII letters mapped to upper case.
+pub fun to_upper(b []byte) []byte {
+    return alloc([]byte, 0)
+}

--- a/stdlib/fmt/fmt.run
+++ b/stdlib/fmt/fmt.run
@@ -1,7 +1,10 @@
 package fmt
 
-pub type Format interface {
-    format() string
+use "io"
+
+// Stringer is the interface for types that can format themselves as strings.
+pub type Stringer interface {
+    string() string
 }
 
 // println prints each argument with space separators and a trailing newline.
@@ -17,6 +20,11 @@ pub fun print(args ...any) {
 // printf formats according to a format string with Go-style verbs
 // (%d, %s, %f, %v, %t, %x, %o, %b, %e, %g) and prints the result.
 pub fun printf(format string, args ...any) {
+}
+
+// eprintln prints each argument with space separators and a trailing newline
+// to stderr.
+pub fun eprintln(args ...any) {
 }
 
 // sprintf formats and returns a string using Go-style verbs.

--- a/stdlib/io/io.run
+++ b/stdlib/io/io.run
@@ -15,48 +15,50 @@ pub type Closer interface {
     close() !void
 }
 
-// File represents an open file descriptor.
-pub File struct {
-    implements {
-        Reader
-        Writer
-        Closer
-    }
-
-    fd   int
-    path string
+// Seeker is the interface for types that can seek to a position.
+pub type Seeker interface {
+    seek(offset int, whence SeekWhence) !int
 }
 
-// open opens a file at the given path with the specified mode.
-// Mode can be "r" (read), "w" (write), "a" (append), "rw" (read/write).
-pub fun open(path string, mode string) !File {
-    fd := try @syscall.open(path, 0, 0)
-    return File{ fd: fd, path: path }
+// ReadWriter is the interface that combines Reader and Writer.
+pub type ReadWriter interface {
+    read(buf []byte) !int
+    write(buf []byte) !int
 }
 
-// read reads up to len(buf) bytes into buf. Returns the number of bytes read.
-pub fun (f &File) read(buf []byte) !int {
-    return try @syscall.read(f.fd, buf, len(buf))
+// ReadCloser is the interface that combines Reader and Closer.
+pub type ReadCloser interface {
+    read(buf []byte) !int
+    close() !void
 }
 
-// write writes buf to the file. Returns the number of bytes written.
-pub fun (f &File) write(buf []byte) !int {
-    return try @syscall.write(f.fd, buf, len(buf))
+// WriteCloser is the interface that combines Writer and Closer.
+pub type WriteCloser interface {
+    write(buf []byte) !int
+    close() !void
 }
 
-// close closes the file.
-pub fun (f &File) close() !void {
-    try @syscall.close(f.fd)
+// ReadWriteCloser is the interface that combines Reader, Writer, and Closer.
+pub type ReadWriteCloser interface {
+    read(buf []byte) !int
+    write(buf []byte) !int
+    close() !void
 }
 
-// stdin is the standard input file.
-pub var stdin = File{ fd: 0, path: "<stdin>" }
+// ReadSeeker is the interface that combines Reader and Seeker.
+pub type ReadSeeker interface {
+    read(buf []byte) !int
+    seek(offset int, whence SeekWhence) !int
+}
 
-// stdout is the standard output file.
-pub var stdout = File{ fd: 1, path: "<stdout>" }
+// SeekWhence specifies how to interpret a seek offset.
+pub type SeekWhence = .start | .current | .end
 
-// stderr is the standard error file.
-pub var stderr = File{ fd: 2, path: "<stderr>" }
+// IoError represents common I/O error conditions.
+pub type IoError = .unexpectedEof
+    | .brokenPipe
+    | .timeout
+    | .closed
 
 // BufferedReader wraps a Reader with an internal buffer for efficiency.
 pub BufferedReader struct {
@@ -114,7 +116,39 @@ pub fun (bw &BufferedWriter) write(buf []byte) !int {
 pub fun (bw &BufferedWriter) flush() !void {
 }
 
+// Discard is a Writer that discards all data written to it.
+Discard struct {
+    implements {
+        Writer
+    }
+}
+
+// write discards all data and reports success.
+fun (d &Discard) write(buf []byte) !int {
+    return len(buf)
+}
+
+// discard is a Writer that discards all data written to it.
+pub var discard = Discard{}
+
 // read_all reads all bytes from a Reader until EOF.
 pub fun read_all(reader Reader) ![]byte {
     return alloc([]byte, 0)
+}
+
+// copy copies from src to dst until EOF is reached on src.
+// Returns the number of bytes copied.
+pub fun copy(dst Writer, src Reader) !int {
+    return 0
+}
+
+// copy_n copies exactly n bytes from src to dst.
+// Returns the number of bytes copied.
+pub fun copy_n(dst Writer, src Reader, n int) !int {
+    return 0
+}
+
+// limit_reader returns a Reader that reads from r but stops after n bytes.
+pub fun limit_reader(reader Reader, n int) Reader {
+    return reader
 }

--- a/stdlib/os/os.run
+++ b/stdlib/os/os.run
@@ -9,12 +9,30 @@ pub type FileError = .notFound
     | .isDirectory
     | .notDirectory
     | .diskFull
+    | .tooManyOpen
+
+// FileMode represents the type of a file.
+pub type FileMode = .regular
+    | .directory
+    | .symlink
+    | .socket
+    | .pipe
+    | .device
 
 // FileInfo contains metadata about a file.
 pub FileInfo struct {
-    name   string
-    size   int
-    is_dir bool
+    name     string
+    size     int
+    is_dir   bool
+    mode     FileMode
+    mod_time int
+}
+
+// DirEntry represents an entry in a directory listing.
+pub DirEntry struct {
+    name      string
+    is_dir    bool
+    file_type FileMode
 }
 
 // File represents an open operating system file.
@@ -23,6 +41,7 @@ pub File struct {
         io.Reader
         io.Writer
         io.Closer
+        io.Seeker
     }
 
     fd   int
@@ -41,6 +60,12 @@ pub fun create(path string) !File {
     return File{ fd: fd, path: path }
 }
 
+// open_file opens a file with the specified flags and permission mode.
+pub fun open_file(path string, flags int, mode int) !File {
+    fd := try @syscall.open(path, flags, mode)
+    return File{ fd: fd, path: path }
+}
+
 // read reads up to len(buf) bytes into buf.
 pub fun (f &File) read(buf []byte) !int {
     return try @syscall.read(f.fd, buf, len(buf))
@@ -55,6 +80,20 @@ pub fun (f &File) write(buf []byte) !int {
 pub fun (f &File) close() !void {
     try @syscall.close(f.fd)
 }
+
+// seek sets the offset for the next read or write on the file.
+pub fun (f &File) seek(offset int, whence io.SeekWhence) !int {
+    return 0
+}
+
+// stdin is the standard input file.
+pub var stdin = File{ fd: 0, path: "<stdin>" }
+
+// stdout is the standard output file.
+pub var stdout = File{ fd: 1, path: "<stdout>" }
+
+// stderr is the standard error file.
+pub var stderr = File{ fd: 2, path: "<stderr>" }
 
 // args returns the command-line arguments, starting with the program name.
 pub fun args() []string {
@@ -71,8 +110,32 @@ pub fun getenv(key string) string? {
 pub fun setenv(key string, value string) !void {
 }
 
+// unsetenv removes the environment variable named by key.
+pub fun unsetenv(key string) !void {
+}
+
+// environ returns all environment variables as a slice of "KEY=VALUE" strings.
+pub fun environ() []string {
+    return alloc([]string, 0)
+}
+
 // exit terminates the program with the given exit code.
 pub fun exit(code int) {
+}
+
+// getpid returns the process ID of the current process.
+pub fun getpid() int {
+    return 0
+}
+
+// hostname returns the hostname of the machine.
+pub fun hostname() !string {
+    return ""
+}
+
+// user_home_dir returns the home directory of the current user.
+pub fun user_home_dir() !string {
+    return ""
 }
 
 // mkdir creates a directory at the given path.
@@ -91,9 +154,52 @@ pub fun remove(path string) !void {
 pub fun remove_all(path string) !void {
 }
 
+// rename renames (moves) a file or directory from old_path to new_path.
+pub fun rename(old_path string, new_path string) !void {
+}
+
+// symlink creates a symbolic link that points to target.
+pub fun symlink(target string, link string) !void {
+}
+
+// read_link returns the destination of the named symbolic link.
+pub fun read_link(path string) !string {
+    return ""
+}
+
+// chmod changes the permission bits of the named file.
+pub fun chmod(path string, mode int) !void {
+}
+
+// chown changes the numeric uid and gid of the named file.
+pub fun chown(path string, uid int, gid int) !void {
+}
+
 // stat returns file info for the named path.
 pub fun stat(path string) !FileInfo {
-    return FileInfo{ name: "", size: 0, is_dir: false }
+    return FileInfo{ name: "", size: 0, is_dir: false, mode: .regular, mod_time: 0 }
+}
+
+// lstat returns file info for the named path without following symlinks.
+pub fun lstat(path string) !FileInfo {
+    return FileInfo{ name: "", size: 0, is_dir: false, mode: .regular, mod_time: 0 }
+}
+
+// read_dir reads the named directory and returns a list of directory entries.
+pub fun read_dir(path string) ![]DirEntry {
+    return alloc([]DirEntry, 0)
+}
+
+// temp_dir returns the default directory for temporary files.
+pub fun temp_dir() string {
+    return ""
+}
+
+// temp_file creates a new temporary file with the given prefix in the
+// default temp directory. The caller is responsible for closing and
+// removing the file.
+pub fun temp_file(prefix string) !File {
+    return File{ fd: 0, path: "" }
 }
 
 // cwd returns the current working directory.
@@ -112,4 +218,51 @@ pub fun read_file(path string) ![]byte {
 
 // write_file writes data to a file, creating it if necessary.
 pub fun write_file(path string, data []byte) !void {
+}
+
+// join_path joins any number of path elements into a single path,
+// separating them with the OS-specific path separator.
+pub fun join_path(parts []string) string {
+    return ""
+}
+
+// base returns the last element of path.
+pub fun base(path string) string {
+    return ""
+}
+
+// dir returns all but the last element of path.
+pub fun dir(path string) string {
+    return ""
+}
+
+// ext returns the file name extension used by path.
+pub fun ext(path string) string {
+    return ""
+}
+
+// clean returns the shortest path name equivalent to path by purely
+// lexical processing.
+pub fun clean(path string) string {
+    return ""
+}
+
+// abs returns an absolute representation of path.
+pub fun abs(path string) !string {
+    return ""
+}
+
+// is_abs reports whether the path is absolute.
+pub fun is_abs(path string) bool {
+    return false
+}
+
+// split_path splits path into a directory and file component.
+pub fun split_path(path string) struct { dir string, file string } {
+    return .{ dir: "", file: "" }
+}
+
+// glob returns the names of all files matching the given pattern.
+pub fun glob(pattern string) ![]string {
+    return alloc([]string, 0)
 }

--- a/stdlib/strings/strings.run
+++ b/stdlib/strings/strings.run
@@ -1,5 +1,33 @@
 package strings
 
+// Builder is a type for efficiently building strings by repeated
+// concatenation. It minimizes memory copying.
+pub Builder struct {
+    buf []byte
+}
+
+// write_string appends the contents of s to the builder's buffer.
+pub fun (b &Builder) write_string(s string) {
+}
+
+// write_byte appends a single byte to the builder's buffer.
+pub fun (b &Builder) write_byte(c byte) {
+}
+
+// string returns the accumulated string and resets the builder.
+pub fun (b &Builder) string() string {
+    return ""
+}
+
+// reset resets the builder to be empty.
+pub fun (b &Builder) reset() {
+}
+
+// len returns the number of accumulated bytes.
+pub fun (b @Builder) len() int {
+    return 0
+}
+
 // contains reports whether substr is within s.
 pub fun contains(s string, substr string) bool {
     return false
@@ -34,6 +62,18 @@ pub fun count(s string, substr string) int {
 
 // split splits s around each instance of sep, returning a slice of substrings.
 pub fun split(s string, sep string) []string {
+    return alloc([]string, 0)
+}
+
+// split_n splits s around the first n instances of sep.
+// If n < 0, there is no limit on the number of splits.
+pub fun split_n(s string, sep string, n int) []string {
+    return alloc([]string, 0)
+}
+
+// fields splits s around runs of whitespace characters,
+// returning a slice of substrings with no empty strings.
+pub fun fields(s string) []string {
     return alloc([]string, 0)
 }
 
@@ -81,6 +121,12 @@ pub fun trim_suffix(s string, suffix string) string {
     return ""
 }
 
+// trim_chars returns s with all leading and trailing characters
+// contained in cutset removed.
+pub fun trim_chars(s string, cutset string) string {
+    return ""
+}
+
 // to_upper returns s with all Unicode letters mapped to their upper case.
 pub fun to_upper(s string) string {
     return ""
@@ -91,9 +137,19 @@ pub fun to_lower(s string) string {
     return ""
 }
 
+// to_title returns s with the first letter of each word capitalized.
+pub fun to_title(s string) string {
+    return ""
+}
+
 // repeat returns a string consisting of count copies of s.
 pub fun repeat(s string, count int) string {
     return ""
+}
+
+// equal_fold reports whether s and t are equal under Unicode case-folding.
+pub fun equal_fold(a string, b string) bool {
+    return false
 }
 
 // starts_with is an alias for has_prefix.


### PR DESCRIPTION
## Summary
- **io** (#134): Add `Seeker` interface, composite interfaces (`ReadWriter`, `ReadCloser`, `WriteCloser`, `ReadWriteCloser`, `ReadSeeker`), `SeekWhence`/`IoError` sum types, `copy`/`copy_n`/`limit_reader` utilities, and `discard` writer. Remove `File`/`stdin`/`stdout`/`stderr` (belong in `os`).
- **fmt** (#135): Rename `Format` to `Stringer` interface with `string()` method, add `eprintln` for stderr, add `io` import.
- **os** (#136): Add `FileMode`/`DirEntry` types, expand `FileInfo`, add `io.Seeker` to `File`. New functions: `open_file`, `lstat`, `read_dir`, `rename`, `symlink`, `read_link`, `chmod`, `chown`, `temp_dir`, `temp_file`, path utilities (`join_path`, `base`, `dir`, `ext`, `clean`, `abs`, `is_abs`, `split_path`, `glob`), and `unsetenv`, `environ`, `getpid`, `hostname`, `user_home_dir`.
- **strings** (#137): Add `Builder` struct with methods. New functions: `split_n`, `fields`, `trim_chars`, `to_title`, `equal_fold`.
- **bytes** (#138): New package with `Buffer` struct (implements `io.Reader`/`io.Writer`) and byte slice functions: `contains`, `index`, `split`, `join`, `trim`, `equal`, `has_prefix`, `has_suffix`, `repeat`, `to_lower`, `to_upper`.

## Test plan
- [ ] Verify all files parse with `zig build run -- check <file>` once Zig is available
- [ ] Confirm all types and functions from issues #134-#138 are present
- [ ] Run `zig build test` to ensure no compiler regressions

Fixes #134, Fixes #135, Fixes #136, Fixes #137, Fixes #138

https://claude.ai/code/session_01Xd3A2PfbbJYavjphF4x5Pg