### PR TITLE
Implement universal assembly language support (M7)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -390,9 +390,11 @@ fun fast_add(a u64, b u64) u64 {
 ```
 
 - `asm(inputs) return_type { instructions }` — inline assembly expression
-- **Inputs**: `expr -> register` binds a Run expression to an abstract register
-- **Return type**: the type of the value produced (read from `r0` by convention)
-- **Clobber list**: `asm(inputs; clobber: r2, r3, memory) { ... }` declares side effects
+- **Inputs**: `expr -> register` binds a Run expression to an abstract register using the `->` (arrow right) operator
+- **Return type**: the type of the value produced (read from `r0` by convention); optional for void assembly
+- **Clobber list**: `asm(inputs; clobber: r2, r3, memory) { ... }` declares side effects — the `;` separates inputs from the clobber clause
+- **No-input form**: `asm() { instructions }` for assembly with no inputs or outputs
+- **Platform conditionals**: Inside the assembly body, `#platform_name { ... }` selects instructions for a specific target (e.g., `#x86_64`, `#arm64`). The `#` token introduces the platform selector
 
 ### Abstract Register Model
 

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -36,6 +36,8 @@ pub const Ast = struct {
         expected_string_literal,
         invalid_token,
         invalid_alloc_type,
+        expected_asm_register,
+        expected_arrow_right,
         unexpected_eof,
     };
 
@@ -276,5 +278,30 @@ pub const Node = struct {
         /// `.{ field1: val1, field2: val2 }`
         /// lhs = null_node, rhs = extra_data start for field inits
         anon_struct_literal,
+
+        // Assembly
+        /// `asm(inputs; clobber: regs) ret_type { body }`
+        /// main_token = kw_asm
+        /// lhs = extra_data start, rhs = body block node
+        /// extra_data layout: [input_count, input1, ..., inputN, clobber_count, clobber1, ..., clobberM, ret_type_node]
+        asm_expr,
+        /// Input binding: `expr -> register`
+        /// main_token = register identifier token
+        /// lhs = expression node, rhs = null_node
+        asm_input,
+        /// Assembly body block containing raw assembly text and optional platform conditionals
+        /// main_token = l_brace token
+        /// lhs = extra_data start for body items, rhs = body item count
+        /// Body items are either asm_simple_body or asm_platform nodes
+        asm_body,
+        /// Raw assembly text span (non-platform-conditional instructions)
+        /// main_token = first token of text span
+        /// lhs = source start offset, rhs = source end offset
+        asm_simple_body,
+        /// Platform-conditional section: `#x86_64 { ... }`
+        /// main_token = hash token
+        /// lhs = source start offset (of body text), rhs = source end offset
+        /// The platform name is the identifier token at main_token + 1
+        asm_platform,
     };
 };

--- a/src/codegen_c.zig
+++ b/src/codegen_c.zig
@@ -185,6 +185,13 @@ pub const CCodegen = struct {
             .try_unwrap => "int64_t",
             .closure_create => "void*",
             .cast => "int64_t",
+            .inline_asm => blk: {
+                const ai = inst.arg1;
+                if (ai < self.module.asm_infos.items.len) {
+                    break :blk self.module.asm_infos.items[ai].return_type;
+                }
+                break :blk "int64_t";
+            },
             .phi => "int64_t",
             else => "int64_t",
         };
@@ -444,7 +451,99 @@ pub const CCodegen = struct {
                 try self.emitIndent();
                 try self.writer().print("/* phi _t{d} */\n", .{inst.result});
             },
+            .inline_asm => {
+                try self.emitInlineAsm(inst);
+            },
             .nop => {},
+        }
+    }
+
+    /// Emit a GCC-style inline assembly statement from AsmInfo.
+    fn emitInlineAsm(self: *CCodegen, inst: ir.Inst) !void {
+        const asm_idx = inst.arg1;
+        if (asm_idx >= self.module.asm_infos.items.len) {
+            try self.emitIndent();
+            try self.writer().print("/* invalid asm_info index */\n", .{});
+            return;
+        }
+        const info = self.module.asm_infos.items[asm_idx];
+
+        try self.emitIndent();
+
+        // Determine if we have an output (result != 0 and return type isn't void)
+        const has_output = inst.result != 0 and !std.mem.eql(u8, info.return_type, "void");
+
+        // Start the __asm__ block
+        try self.writer().print("__asm__ __volatile__(\n", .{});
+
+        // Emit template — handle platform sections
+        try self.emitIndent();
+        try self.writer().print("    \"", .{});
+        if (info.platform_sections.items.len > 0) {
+            // Use platform-specific template based on target
+            const target_arch = @import("builtin").cpu.arch;
+            var found = false;
+            for (info.platform_sections.items) |section| {
+                const matches = (target_arch == .x86_64 and std.mem.eql(u8, section.platform, "x86_64")) or
+                    (target_arch == .aarch64 and std.mem.eql(u8, section.platform, "arm64"));
+                if (matches) {
+                    try self.emitAsmTemplate(section.template);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found and info.template.len > 0) {
+                try self.emitAsmTemplate(info.template);
+            }
+        } else {
+            try self.emitAsmTemplate(info.template);
+        }
+        try self.writer().print("\"\n", .{});
+
+        // Output operands
+        try self.emitIndent();
+        if (has_output) {
+            try self.writer().print("    : \"=r\"(_t{d})\n", .{inst.result});
+        } else {
+            try self.writer().print("    : /* no outputs */\n", .{});
+        }
+
+        // Input operands
+        try self.emitIndent();
+        try self.writer().print("    : ", .{});
+        for (info.inputs.items, 0..) |input, i| {
+            if (i > 0) try self.writer().print(", ", .{});
+            const constraint = mapRegisterConstraint(input.register);
+            try self.writer().print("\"{s}\"(_t{d})", .{ constraint, input.ref });
+        }
+        try self.writer().print("\n", .{});
+
+        // Clobbers
+        try self.emitIndent();
+        try self.writer().print("    : ", .{});
+        for (info.clobbers.items, 0..) |clobber, i| {
+            if (i > 0) try self.writer().print(", ", .{});
+            try self.writer().print("\"{s}\"", .{clobber});
+        }
+        try self.writer().print("\n", .{});
+
+        try self.emitIndent();
+        try self.writer().print(");\n", .{});
+    }
+
+    /// Emit assembly template text, converting newlines to \\n for GCC inline asm.
+    fn emitAsmTemplate(self: *CCodegen, template: []const u8) !void {
+        const trimmed = std.mem.trim(u8, template, " \t\n\r");
+        var iter = std.mem.splitScalar(u8, trimmed, '\n');
+        var first = true;
+        while (iter.next()) |line| {
+            const tline = std.mem.trim(u8, line, " \t\r");
+            if (tline.len == 0) continue;
+            if (!first) {
+                try self.writer().print("\\n", .{});
+            }
+            try self.writer().print("{s}", .{tline});
+            first = false;
         }
     }
 
@@ -566,6 +665,29 @@ pub const CCodegen = struct {
         return self.output.writer(self.allocator);
     }
 };
+
+/// Map abstract register names to GCC/Clang register constraints.
+/// Uses target-appropriate constraints for the current compilation platform.
+fn mapRegisterConstraint(register: []const u8) []const u8 {
+    const arch = @import("builtin").cpu.arch;
+    if (arch == .x86_64) {
+        // x86-64 System V ABI register mapping
+        if (std.mem.eql(u8, register, "r0")) return "a"; // rax
+        if (std.mem.eql(u8, register, "r1")) return "b"; // rbx
+        if (std.mem.eql(u8, register, "r2")) return "c"; // rcx
+        if (std.mem.eql(u8, register, "r3")) return "d"; // rdx
+        if (std.mem.eql(u8, register, "r4")) return "S"; // rsi
+        if (std.mem.eql(u8, register, "r5")) return "D"; // rdi
+        if (std.mem.eql(u8, register, "sp")) return "{rsp}";
+        if (std.mem.eql(u8, register, "fp")) return "{rbp}";
+    } else if (arch == .aarch64) {
+        // ARM64 AAPCS register mapping — all are general purpose "r" constraint
+        if (std.mem.eql(u8, register, "sp")) return "{sp}";
+        if (std.mem.eql(u8, register, "fp")) return "{x29}";
+    }
+    // Default: use general-purpose register constraint
+    return "r";
+}
 
 // Tests
 

--- a/src/driver.zig
+++ b/src/driver.zig
@@ -12,6 +12,7 @@ const ir = @import("ir.zig");
 const dce = @import("dce.zig");
 const const_fold = @import("const_fold.zig");
 const codegen_c = @import("codegen_c.zig");
+const rasm = @import("rasm.zig");
 const diag_mod = @import("diagnostics.zig");
 
 const File = std.fs.File;
@@ -80,6 +81,8 @@ pub fn compile(allocator: std.mem.Allocator, options: CompileOptions) CompileErr
                 .expected_string_literal => "expected string literal",
                 .invalid_token => "invalid token",
                 .invalid_alloc_type => "invalid alloc type",
+                .expected_asm_register => "expected register name in assembly input binding",
+                .expected_arrow_right => "expected '->' in assembly input binding",
                 .unexpected_eof => "unexpected end of file",
             };
             const d = diag_mod.Diagnostic{
@@ -236,13 +239,57 @@ pub fn compile(allocator: std.mem.Allocator, options: CompileOptions) CompileErr
     // Find runtime directory (relative to current working dir)
     const runtime_dir = "src/runtime";
 
-    invokeZigCC(allocator, tmp_path, out_path, runtime_dir) catch {
+    // 9b. Discover and compile .rasm files alongside the source
+    const source_dir = std.fs.path.dirname(options.input_path) orelse ".";
+    const arch = rasm.Arch.fromBuiltin();
+    var rasm_asm_files: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (rasm_asm_files.items) |path| {
+            allocator.free(path);
+        }
+        rasm_asm_files.deinit(allocator);
+    }
+
+    var rasm_files: std.ArrayList([]const u8) = rasm.discoverRasmFiles(allocator, source_dir, arch) catch .empty;
+    defer {
+        for (rasm_files.items) |path| {
+            allocator.free(path);
+        }
+        rasm_files.deinit(allocator);
+    }
+
+    for (rasm_files.items) |rasm_path| {
+        const rasm_source = readFile(allocator, rasm_path) catch continue;
+        defer allocator.free(rasm_source);
+
+        var parsed = rasm.parseRasmFile(allocator, rasm_source) catch continue;
+        defer parsed.deinit(allocator);
+
+        const gas_source = rasm.generateGasFile(allocator, &parsed, arch) catch continue;
+        defer allocator.free(gas_source);
+
+        // Write .S file
+        const asm_path = std.fmt.allocPrint(allocator, "/tmp/run_rasm_{s}.S", .{
+            std.fs.path.stem(rasm_path),
+        }) catch continue;
+
+        const asm_file = std.fs.cwd().createFile(asm_path, .{}) catch continue;
+        defer asm_file.close();
+        asm_file.writeAll(gas_source) catch continue;
+
+        rasm_asm_files.append(allocator, asm_path) catch continue;
+    }
+
+    invokeZigCC(allocator, tmp_path, out_path, runtime_dir, rasm_asm_files.items) catch {
         stderr.writeAll("error: C compilation failed\n") catch {};
         return CompileError.CCompileFailed;
     };
 
-    // Clean up temp file
+    // Clean up temp files
     std.fs.cwd().deleteFile(tmp_path) catch {};
+    for (rasm_asm_files.items) |asm_path| {
+        std.fs.cwd().deleteFile(asm_path) catch {};
+    }
 
     if (options.command == .run) {
         // Ensure binary path has ./ prefix for execution
@@ -326,6 +373,7 @@ pub fn invokeZigCC(
     c_source_path: []const u8,
     output_path: []const u8,
     runtime_dir: []const u8,
+    extra_asm_files: []const []const u8,
 ) !void {
     const runtime_sources = [_][]const u8{
         "run_main.c",
@@ -366,6 +414,11 @@ pub fn invokeZigCC(
     if (asm_source) |asm_name| {
         const asm_path = try std.fs.path.join(allocator, &.{ runtime_dir, asm_name });
         try args.append(allocator, asm_path);
+    }
+
+    // Add extra .rasm-generated assembly files
+    for (extra_asm_files) |extra_asm| {
+        try args.append(allocator, extra_asm);
     }
 
     // Include path for runtime headers

--- a/src/formatter.zig
+++ b/src/formatter.zig
@@ -114,6 +114,11 @@ pub const Formatter = struct {
             .variadic_param => try self.formatVariadicParam(node),
             .receiver => try self.formatReceiver(node),
             .method_sig => try self.formatMethodSig(node),
+            .asm_expr => try self.formatAsmExpr(node),
+            .asm_input => try self.formatAsmInput(node),
+            .asm_body => try self.formatAsmBody(node),
+            .asm_simple_body => try self.formatAsmSimpleBody(node),
+            .asm_platform => try self.formatAsmPlatform(node),
         }
     }
 
@@ -857,6 +862,98 @@ pub const Formatter = struct {
             }
             try self.write(" ");
         }
+        try self.write("}");
+    }
+
+    // --- Assembly ---
+
+    fn formatAsmExpr(self: *Formatter, node: Node) !void {
+        try self.write("asm(");
+        const extra = self.tree.extra_data.items;
+        const start = node.data.lhs;
+        const input_count = extra[start];
+
+        // Format inputs
+        var i: u32 = 0;
+        while (i < input_count) : (i += 1) {
+            if (i > 0) try self.write(", ");
+            try self.formatNode(extra[start + 1 + i]);
+        }
+
+        // Format clobbers
+        const clobber_offset = start + 1 + input_count;
+        const clobber_count = extra[clobber_offset];
+        if (clobber_count > 0) {
+            try self.write("; clobber: ");
+            var j: u32 = 0;
+            while (j < clobber_count) : (j += 1) {
+                if (j > 0) try self.write(", ");
+                try self.formatNode(extra[clobber_offset + 1 + j]);
+            }
+        }
+
+        try self.write(")");
+
+        // Format return type
+        const ret_type_idx = extra[clobber_offset + 1 + clobber_count];
+        if (ret_type_idx != null_node) {
+            try self.write(" ");
+            try self.formatNode(ret_type_idx);
+        }
+
+        try self.write(" ");
+        try self.formatNode(node.data.rhs);
+    }
+
+    fn formatAsmInput(self: *Formatter, node: Node) !void {
+        try self.formatNode(node.data.lhs);
+        try self.write(" -> ");
+        try self.writeToken(node.main_token);
+    }
+
+    fn formatAsmBody(self: *Formatter, node: Node) !void {
+        try self.write("{\n");
+        self.indent_level += 1;
+        const extra = self.tree.extra_data.items;
+        const start = node.data.lhs;
+        const count = node.data.rhs;
+        var i: u32 = 0;
+        while (i < count) : (i += 1) {
+            try self.writeIndent();
+            try self.formatNode(extra[start + i]);
+            try self.newline();
+        }
+        self.indent_level -= 1;
+        try self.writeIndent();
+        try self.write("}");
+    }
+
+    fn formatAsmSimpleBody(self: *Formatter, node: Node) !void {
+        // Emit raw source text for assembly instructions
+        const src_start = node.data.lhs;
+        const src_end = node.data.rhs;
+        if (src_start < src_end and src_end <= self.source.len) {
+            const text = std.mem.trim(u8, self.source[src_start..src_end], " \t\n\r");
+            try self.write(text);
+        }
+    }
+
+    fn formatAsmPlatform(self: *Formatter, node: Node) !void {
+        try self.write("#");
+        // Platform name is the token after hash
+        try self.writeToken(node.main_token + 1);
+        try self.write(" {\n");
+        self.indent_level += 1;
+        const src_start = node.data.lhs;
+        const src_end = node.data.rhs;
+        if (src_start < src_end and src_end <= self.source.len) {
+            const text = std.mem.trim(u8, self.source[src_start..src_end], " \t\n\r");
+            try self.writeIndent();
+            try self.write(text);
+            try self.newline();
+        }
+        self.indent_level -= 1;
+        try self.writeIndent();
         try self.write("}");
     }
 

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -92,6 +92,9 @@ pub const Inst = struct {
         local_set, // arg1 = local_idx, arg2 = value ref
         local_get, // result = ref, arg1 = local_idx
 
+        // Inline assembly
+        inline_asm, // result = asm output, arg1 = asm_info index in Module.asm_infos
+
         // SSA / misc
         phi,
         nop,
@@ -211,11 +214,42 @@ pub const LocalInfo = struct {
     c_type: []const u8,
 };
 
+/// Metadata for an inline assembly expression.
+pub const AsmInfo = struct {
+    /// The assembly template string (raw source text of instructions)
+    template: []const u8,
+    /// Input operands: each is (register_name, ir_ref)
+    inputs: std.ArrayList(AsmOperand),
+    /// Clobber register names
+    clobbers: std.ArrayList([]const u8),
+    /// C return type string, or "void" if no return
+    return_type: []const u8,
+    /// Platform-conditional sections (optional)
+    platform_sections: std.ArrayList(PlatformSection),
+
+    pub const PlatformSection = struct {
+        platform: []const u8,
+        template: []const u8,
+    };
+
+    pub fn deinit(self: *AsmInfo, allocator: std.mem.Allocator) void {
+        self.inputs.deinit(allocator);
+        self.clobbers.deinit(allocator);
+        self.platform_sections.deinit(allocator);
+    }
+};
+
+pub const AsmOperand = struct {
+    register: []const u8,
+    ref: Ref,
+};
+
 pub const Module = struct {
     functions: std.ArrayList(Function),
     string_constants: std.ArrayList(StringConstant),
     call_infos: std.ArrayList(CallInfo),
     local_infos: std.ArrayList(LocalInfo),
+    asm_infos: std.ArrayList(AsmInfo),
     /// Strings allocated by the lowering pass that this module owns.
     owned_strings: std.ArrayList([]const u8),
 
@@ -225,6 +259,7 @@ pub const Module = struct {
             .string_constants = .empty,
             .call_infos = .empty,
             .local_infos = .empty,
+            .asm_infos = .empty,
             .owned_strings = .empty,
         };
     }
@@ -240,6 +275,10 @@ pub const Module = struct {
         }
         self.call_infos.deinit(allocator);
         self.local_infos.deinit(allocator);
+        for (self.asm_infos.items) |*ai| {
+            ai.deinit(allocator);
+        }
+        self.asm_infos.deinit(allocator);
         for (self.owned_strings.items) |s| {
             allocator.free(s);
         }
@@ -295,6 +334,12 @@ pub const Module = struct {
         }
         const index: u32 = @intCast(self.local_infos.items.len);
         try self.local_infos.append(allocator, .{ .name = name, .c_type = c_type });
+        return index;
+    }
+
+    pub fn addAsmInfo(self: *Module, allocator: std.mem.Allocator, info: AsmInfo) !u32 {
+        const index: u32 = @intCast(self.asm_infos.items.len);
+        try self.asm_infos.append(allocator, info);
         return index;
     }
 

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -215,7 +215,11 @@ pub const Lexer = struct {
         const c = self.peek();
         return switch (c) {
             '+' => self.advance1(.plus),
-            '-' => self.advance1(.minus),
+            '-' => blk: {
+                if (self.peekNext() == @as(u8, '>'))
+                    break :blk self.advance2(.arrow_right);
+                break :blk self.advance1(.minus);
+            },
             '*' => self.advance1(.star),
             '/' => self.advance1(.slash),
             '%' => self.advance1(.percent),
@@ -230,6 +234,8 @@ pub const Lexer = struct {
             ',' => self.advance1(.comma),
             '?' => self.advance1(.question),
             '|' => self.advance1(.pipe),
+            '#' => self.advance1(.hash),
+            ';' => self.advance1(.semicolon),
             ':' => blk: {
                 if (self.peekNext() == @as(u8, '='))
                     break :blk self.advance2(.colon_equal);
@@ -369,6 +375,32 @@ test "lex colon vs colon_colon" {
     try std.testing.expectEqual(Tag.colon, lexer.next().tag);
     try std.testing.expectEqual(Tag.colon_colon, lexer.next().tag);
     try std.testing.expectEqual(Tag.colon, lexer.next().tag);
+    try std.testing.expectEqual(Tag.eof, lexer.next().tag);
+}
+
+test "lex arrow_right and hash and semicolon" {
+    var lexer = Lexer.init("-> # ;");
+    try std.testing.expectEqual(Tag.arrow_right, lexer.next().tag);
+    try std.testing.expectEqual(Tag.hash, lexer.next().tag);
+    try std.testing.expectEqual(Tag.semicolon, lexer.next().tag);
+    try std.testing.expectEqual(Tag.eof, lexer.next().tag);
+}
+
+test "lex asm keyword" {
+    var lexer = Lexer.init("asm clobber");
+    try std.testing.expectEqual(Tag.kw_asm, lexer.next().tag);
+    try std.testing.expectEqual(Tag.kw_clobber, lexer.next().tag);
+    try std.testing.expectEqual(Tag.eof, lexer.next().tag);
+}
+
+test "lex minus vs arrow_right" {
+    var lexer = Lexer.init("a - b a -> r0");
+    try std.testing.expectEqual(Tag.identifier, lexer.next().tag);
+    try std.testing.expectEqual(Tag.minus, lexer.next().tag);
+    try std.testing.expectEqual(Tag.identifier, lexer.next().tag);
+    try std.testing.expectEqual(Tag.identifier, lexer.next().tag);
+    try std.testing.expectEqual(Tag.arrow_right, lexer.next().tag);
+    try std.testing.expectEqual(Tag.identifier, lexer.next().tag);
     try std.testing.expectEqual(Tag.eof, lexer.next().tag);
 }
 

--- a/src/lower.zig
+++ b/src/lower.zig
@@ -665,8 +665,133 @@ const LoweringContext = struct {
                 return r;
             },
             .if_expr => return try self.lowerIfExpr(node_idx),
+            .asm_expr => return try self.lowerAsmExpr(node_idx),
             else => return ir.null_ref,
         }
+    }
+
+    fn lowerAsmExpr(self: *LoweringContext, node_idx: NodeIndex) LowerError!ir.Ref {
+        const node = self.tree.nodes.items[node_idx];
+        const extra = self.tree.extra_data.items;
+        const extra_start = node.data.lhs;
+        const body_node_idx = node.data.rhs;
+
+        // Parse extra_data layout: [input_count, input1..N, clobber_count, clobber1..M, ret_type_node]
+        const input_count = extra[extra_start];
+
+        // Lower input expressions and collect register bindings
+        var inputs: std.ArrayList(ir.AsmOperand) = .empty;
+        defer inputs.deinit(self.allocator);
+
+        var i: u32 = 0;
+        while (i < input_count) : (i += 1) {
+            const input_node_idx = extra[extra_start + 1 + i];
+            const input_node = self.tree.nodes.items[input_node_idx];
+            // input_node.tag == .asm_input: lhs = expression, main_token = register name
+            const expr_ref = try self.lowerExpr(input_node.data.lhs);
+            const reg_name = self.tokenSlice(input_node.main_token);
+            try inputs.append(self.allocator, .{ .register = reg_name, .ref = expr_ref });
+        }
+
+        // Clobbers
+        const clobber_offset = extra_start + 1 + input_count;
+        const clobber_count = extra[clobber_offset];
+        var clobbers: std.ArrayList([]const u8) = .empty;
+        defer clobbers.deinit(self.allocator);
+
+        var j: u32 = 0;
+        while (j < clobber_count) : (j += 1) {
+            const clobber_node_idx = extra[clobber_offset + 1 + j];
+            const clobber_node = self.tree.nodes.items[clobber_node_idx];
+            const clobber_name = self.tokenSlice(clobber_node.main_token);
+            try clobbers.append(self.allocator, clobber_name);
+        }
+
+        // Return type
+        const ret_type_offset = clobber_offset + 1 + clobber_count;
+        const ret_type_node = extra[ret_type_offset];
+        const return_type: []const u8 = if (ret_type_node != null_node) blk: {
+            const rt_node = self.tree.nodes.items[ret_type_node];
+            const type_name = self.tokenSlice(rt_node.main_token);
+            // Map Run types to C types
+            break :blk if (std.mem.eql(u8, type_name, "u64") or std.mem.eql(u8, type_name, "i64") or std.mem.eql(u8, type_name, "int"))
+                "int64_t"
+            else if (std.mem.eql(u8, type_name, "u32") or std.mem.eql(u8, type_name, "i32"))
+                "int32_t"
+            else if (std.mem.eql(u8, type_name, "f32"))
+                "float"
+            else if (std.mem.eql(u8, type_name, "f64") or std.mem.eql(u8, type_name, "float"))
+                "double"
+            else if (std.mem.eql(u8, type_name, "bool"))
+                "bool"
+            else
+                "int64_t";
+        } else "void";
+
+        // Extract assembly body text from body node
+        var template: []const u8 = "";
+        var platform_sections: std.ArrayList(ir.AsmInfo.PlatformSection) = .empty;
+        defer platform_sections.deinit(self.allocator);
+
+        if (body_node_idx != null_node) {
+            const body_node = self.tree.nodes.items[body_node_idx];
+            if (body_node.tag == .asm_body) {
+                const body_start = body_node.data.lhs;
+                const body_count = body_node.data.rhs;
+                var k: u32 = 0;
+                while (k < body_count) : (k += 1) {
+                    const item_idx = extra[body_start + k];
+                    const item = self.tree.nodes.items[item_idx];
+                    if (item.tag == .asm_simple_body) {
+                        const src_start = item.data.lhs;
+                        const src_end = item.data.rhs;
+                        if (src_start < src_end and src_end <= self.tree.source.len) {
+                            template = self.tree.source[src_start..src_end];
+                        }
+                    } else if (item.tag == .asm_platform) {
+                        // Platform conditional: main_token = hash, main_token+1 = platform name
+                        const plat_name = self.tokenSlice(item.main_token + 1);
+                        const src_start = item.data.lhs;
+                        const src_end = item.data.rhs;
+                        var plat_template: []const u8 = "";
+                        if (src_start < src_end and src_end <= self.tree.source.len) {
+                            plat_template = self.tree.source[src_start..src_end];
+                        }
+                        try platform_sections.append(self.allocator, .{
+                            .platform = plat_name,
+                            .template = plat_template,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Clone lists for AsmInfo (it needs to own the data)
+        var info_inputs: std.ArrayList(ir.AsmOperand) = .empty;
+        for (inputs.items) |inp| {
+            try info_inputs.append(self.allocator, inp);
+        }
+        var info_clobbers: std.ArrayList([]const u8) = .empty;
+        for (clobbers.items) |c| {
+            try info_clobbers.append(self.allocator, c);
+        }
+        var info_platforms: std.ArrayList(ir.AsmInfo.PlatformSection) = .empty;
+        for (platform_sections.items) |p| {
+            try info_platforms.append(self.allocator, p);
+        }
+
+        const asm_info = ir.AsmInfo{
+            .template = template,
+            .inputs = info_inputs,
+            .clobbers = info_clobbers,
+            .return_type = return_type,
+            .platform_sections = info_platforms,
+        };
+        const asm_idx = try self.module.addAsmInfo(self.allocator, asm_info);
+
+        const r = self.allocRef();
+        try self.emit(ir.makeInst(.inline_asm, r, asm_idx, 0));
+        return r;
     }
 
     fn lowerIfExpr(self: *LoweringContext, node_idx: NodeIndex) LowerError!ir.Ref {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1477,6 +1477,9 @@ pub const Parser = struct {
             .kw_alloc => {
                 return self.parseAllocExpr();
             },
+            .kw_asm => {
+                return self.parseAsmExpr();
+            },
             .eof => {
                 try self.addError(.unexpected_eof, self.currentLoc(), null);
                 return null_node;
@@ -1487,6 +1490,191 @@ pub const Parser = struct {
                 return null_node;
             },
         };
+    }
+
+    /// Parse inline assembly expression: `asm(inputs; clobber: regs) ret_type { body }`
+    fn parseAsmExpr(self: *Parser) Error!NodeIndex {
+        const tok = self.pos;
+        self.expect(.kw_asm);
+        self.expectToken(.l_paren);
+
+        // Parse input list: expr -> register, ...
+        var inputs: std.ArrayList(NodeIndex) = .empty;
+        defer inputs.deinit(self.tree.allocator);
+
+        while (self.peekTag() != .r_paren and self.peekTag() != .semicolon and !self.isAtEnd()) {
+            const expr = try self.parseExpr();
+
+            if (self.peekTag() != .arrow_right) {
+                try self.addError(.expected_arrow_right, self.currentLoc(), null);
+                break;
+            }
+            self.advance(); // consume ->
+
+            if (self.peekTag() != .identifier) {
+                try self.addError(.expected_asm_register, self.currentLoc(), null);
+                break;
+            }
+            const reg_tok = self.pos;
+            self.advance(); // consume register name
+
+            const input_node = try self.tree.addNode(.{
+                .tag = .asm_input,
+                .main_token = reg_tok,
+                .data = .{ .lhs = expr, .rhs = null_node },
+            });
+            try inputs.append(self.tree.allocator, input_node);
+
+            if (self.peekTag() == .comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        // Parse optional clobber list: ; clobber: reg1, reg2, memory
+        var clobbers: std.ArrayList(NodeIndex) = .empty;
+        defer clobbers.deinit(self.tree.allocator);
+
+        if (self.peekTag() == .semicolon) {
+            self.advance(); // consume ;
+            self.skipNewlines();
+            if (self.peekTag() == .kw_clobber) {
+                self.advance(); // consume clobber
+                self.expectToken(.colon);
+                while (self.peekTag() == .identifier and !self.isAtEnd()) {
+                    const clobber_tok = self.pos;
+                    self.advance();
+                    const clobber_node = try self.tree.addNode(.{
+                        .tag = .ident,
+                        .main_token = clobber_tok,
+                        .data = .{ .lhs = null_node, .rhs = null_node },
+                    });
+                    try clobbers.append(self.tree.allocator, clobber_node);
+                    if (self.peekTag() == .comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        self.expectToken(.r_paren);
+
+        // Parse optional return type
+        var ret_type: NodeIndex = null_node;
+        if (self.isTypeStart()) {
+            ret_type = try self.parseType();
+        }
+
+        self.skipNewlines();
+
+        // Parse assembly body block
+        const body = try self.parseAsmBody();
+
+        // Build extra_data: [input_count, input1, ..., inputN, clobber_count, clobber1, ..., clobberM, ret_type_node]
+        const extra_start: u32 = @intCast(self.tree.extra_data.items.len);
+        _ = try self.tree.addExtra(@intCast(inputs.items.len));
+        for (inputs.items) |input| {
+            _ = try self.tree.addExtra(input);
+        }
+        _ = try self.tree.addExtra(@intCast(clobbers.items.len));
+        for (clobbers.items) |clobber| {
+            _ = try self.tree.addExtra(clobber);
+        }
+        _ = try self.tree.addExtra(ret_type);
+
+        return self.tree.addNode(.{
+            .tag = .asm_expr,
+            .main_token = tok,
+            .data = .{ .lhs = extra_start, .rhs = body },
+        });
+    }
+
+    /// Parse assembly body: `{ instructions }` with optional `#platform { ... }` sections
+    fn parseAsmBody(self: *Parser) Error!NodeIndex {
+        const tok = self.pos;
+        self.expectToken(.l_brace);
+        self.skipNewlines();
+
+        var items: std.ArrayList(NodeIndex) = .empty;
+        defer items.deinit(self.tree.allocator);
+
+        while (self.peekTag() != .r_brace and !self.isAtEnd()) {
+            self.skipNewlines();
+            if (self.peekTag() == .r_brace) break;
+
+            if (self.peekTag() == .hash) {
+                // Platform conditional: #x86_64 { ... } or #arm64 { ... }
+                const hash_tok = self.pos;
+                self.advance(); // consume #
+
+                if (self.peekTag() != .identifier) {
+                    try self.addError(.expected_identifier, self.currentLoc(), null);
+                    break;
+                }
+                self.advance(); // consume platform name
+                self.skipNewlines();
+
+                // Parse the platform body
+                if (self.peekTag() != .l_brace) {
+                    try self.addError(.expected_block, self.currentLoc(), null);
+                    break;
+                }
+                // Record source positions of the inner body
+                self.advance(); // consume {
+                const body_start = self.pos;
+                var depth: u32 = 1;
+                while (depth > 0 and !self.isAtEnd()) {
+                    if (self.peekTag() == .l_brace) depth += 1;
+                    if (self.peekTag() == .r_brace) depth -= 1;
+                    if (depth > 0) self.advance();
+                }
+                const body_end = self.pos;
+                if (self.peekTag() == .r_brace) self.advance(); // consume }
+
+                // Use token positions to capture source range
+                const src_start = if (body_start < self.tokens.len) self.tokens[body_start].loc.start else 0;
+                const src_end = if (body_end < self.tokens.len) self.tokens[body_end].loc.start else src_start;
+
+                const platform_node = try self.tree.addNode(.{
+                    .tag = .asm_platform,
+                    .main_token = hash_tok,
+                    .data = .{ .lhs = src_start, .rhs = src_end },
+                });
+                try items.append(self.tree.allocator, platform_node);
+            } else {
+                // Raw assembly text — collect tokens until we hit a # or }
+                const text_start_tok = self.pos;
+                const src_start = self.tokens[text_start_tok].loc.start;
+                while (self.peekTag() != .r_brace and self.peekTag() != .hash and !self.isAtEnd()) {
+                    self.advance();
+                }
+                const src_end = if (self.pos < self.tokens.len) self.tokens[self.pos].loc.start else src_start;
+
+                const text_node = try self.tree.addNode(.{
+                    .tag = .asm_simple_body,
+                    .main_token = text_start_tok,
+                    .data = .{ .lhs = src_start, .rhs = src_end },
+                });
+                try items.append(self.tree.allocator, text_node);
+            }
+            self.skipNewlines();
+        }
+        self.expectToken(.r_brace);
+
+        const extra_start: u32 = @intCast(self.tree.extra_data.items.len);
+        for (items.items) |item| {
+            _ = try self.tree.addExtra(item);
+        }
+        const count: u32 = @intCast(items.items.len);
+
+        return self.tree.addNode(.{
+            .tag = .asm_body,
+            .main_token = tok,
+            .data = .{ .lhs = extra_start, .rhs = count },
+        });
     }
 
     fn parseClosure(self: *Parser) Error!NodeIndex {
@@ -2772,4 +2960,100 @@ test "parse package declaration and use import" {
     }
     try std.testing.expect(saw_package);
     try std.testing.expect(saw_import);
+}
+
+test "parse basic inline asm expression" {
+    const source = "fn main() {\n    x := asm(a -> r0, b -> r1) u64 {\n        add r0, r0, r1\n    }\n}";
+    var lexer = Lexer.init(source);
+    var tokens = try lexer.tokenize(std.testing.allocator);
+    defer tokens.deinit(std.testing.allocator);
+
+    var parser = Parser.init(std.testing.allocator, tokens.items, source);
+    defer parser.deinit();
+
+    _ = try parser.parseFile();
+    try std.testing.expectEqual(@as(usize, 0), parser.tree.errors.items.len);
+
+    var found_asm = false;
+    var found_inputs: u32 = 0;
+    for (parser.tree.nodes.items) |node| {
+        if (node.tag == .asm_expr) found_asm = true;
+        if (node.tag == .asm_input) found_inputs += 1;
+    }
+    try std.testing.expect(found_asm);
+    try std.testing.expectEqual(@as(u32, 2), found_inputs);
+}
+
+test "parse asm with clobber list" {
+    const source = "fn main() {\n    asm(x -> r0; clobber: r2, r3) {\n        mov r2, r0\n    }\n}";
+    var lexer = Lexer.init(source);
+    var tokens = try lexer.tokenize(std.testing.allocator);
+    defer tokens.deinit(std.testing.allocator);
+
+    var parser = Parser.init(std.testing.allocator, tokens.items, source);
+    defer parser.deinit();
+
+    _ = try parser.parseFile();
+    try std.testing.expectEqual(@as(usize, 0), parser.tree.errors.items.len);
+
+    var found_asm = false;
+    for (parser.tree.nodes.items) |node| {
+        if (node.tag == .asm_expr) {
+            found_asm = true;
+            // Check extra_data: input_count=1, then input node, then clobber_count=2
+            const extra = parser.tree.extra_data.items;
+            const input_count = extra[node.data.lhs];
+            try std.testing.expectEqual(@as(u32, 1), input_count);
+            const clobber_offset = node.data.lhs + 1 + input_count;
+            const clobber_count = extra[clobber_offset];
+            try std.testing.expectEqual(@as(u32, 2), clobber_count);
+        }
+    }
+    try std.testing.expect(found_asm);
+}
+
+test "parse asm with no inputs" {
+    const source = "fn main() {\n    asm() {\n        nop\n    }\n}";
+    var lexer = Lexer.init(source);
+    var tokens = try lexer.tokenize(std.testing.allocator);
+    defer tokens.deinit(std.testing.allocator);
+
+    var parser = Parser.init(std.testing.allocator, tokens.items, source);
+    defer parser.deinit();
+
+    _ = try parser.parseFile();
+    try std.testing.expectEqual(@as(usize, 0), parser.tree.errors.items.len);
+
+    var found_asm = false;
+    for (parser.tree.nodes.items) |node| {
+        if (node.tag == .asm_expr) {
+            found_asm = true;
+            const extra = parser.tree.extra_data.items;
+            const input_count = extra[node.data.lhs];
+            try std.testing.expectEqual(@as(u32, 0), input_count);
+        }
+    }
+    try std.testing.expect(found_asm);
+}
+
+test "parse asm with platform conditionals" {
+    const source = "fn main() {\n    asm(data -> r0) {\n        #x86_64 {\n            popcnt r0, r0\n        }\n        #arm64 {\n            cnt v0.8b, v0.8b\n        }\n    }\n}";
+    var lexer = Lexer.init(source);
+    var tokens = try lexer.tokenize(std.testing.allocator);
+    defer tokens.deinit(std.testing.allocator);
+
+    var parser = Parser.init(std.testing.allocator, tokens.items, source);
+    defer parser.deinit();
+
+    _ = try parser.parseFile();
+    try std.testing.expectEqual(@as(usize, 0), parser.tree.errors.items.len);
+
+    var found_asm = false;
+    var platform_count: u32 = 0;
+    for (parser.tree.nodes.items) |node| {
+        if (node.tag == .asm_expr) found_asm = true;
+        if (node.tag == .asm_platform) platform_count += 1;
+    }
+    try std.testing.expect(found_asm);
+    try std.testing.expectEqual(@as(u32, 2), platform_count);
 }

--- a/src/rasm.zig
+++ b/src/rasm.zig
@@ -1,0 +1,411 @@
+/// Run Assembly (.rasm) file support.
+///
+/// .rasm files contain function declarations with assembly bodies.
+/// Platform suffixes select architecture-specific implementations:
+///   - `file.rasm`       — portable (abstract registers only)
+///   - `file_amd64.rasm` — x86-64 specific
+///   - `file_arm64.rasm` — ARM64 specific
+///
+/// The build system selects the correct file: platform-specific takes priority
+/// over portable versions. .rasm files are compiled to .S (GAS) files and
+/// assembled alongside the generated C code.
+
+const std = @import("std");
+const Lexer = @import("lexer.zig").Lexer;
+const Token = @import("token.zig").Token;
+const Tag = Token.Tag;
+
+/// Represents a parsed .rasm function declaration.
+pub const RasmFunction = struct {
+    name: []const u8,
+    is_pub: bool,
+    params: std.ArrayList(Param),
+    return_type: []const u8,
+    body: []const u8,
+
+    pub const Param = struct {
+        name: []const u8,
+        type_name: []const u8,
+    };
+
+    pub fn deinit(self: *RasmFunction, allocator: std.mem.Allocator) void {
+        self.params.deinit(allocator);
+    }
+};
+
+/// Result of parsing a .rasm file.
+pub const RasmFile = struct {
+    functions: std.ArrayList(RasmFunction),
+
+    pub fn deinit(self: *RasmFile, allocator: std.mem.Allocator) void {
+        for (self.functions.items) |*f| {
+            f.deinit(allocator);
+        }
+        self.functions.deinit(allocator);
+    }
+};
+
+/// Parse a .rasm file into function declarations.
+pub fn parseRasmFile(allocator: std.mem.Allocator, source: []const u8) !RasmFile {
+    var lexer = Lexer.init(source);
+    var tokens = try lexer.tokenize(allocator);
+    defer tokens.deinit(allocator);
+
+    var functions: std.ArrayList(RasmFunction) = .empty;
+    var pos: u32 = 0;
+
+    while (pos < tokens.items.len) {
+        // Skip newlines
+        while (pos < tokens.items.len and tokens.items[pos].tag == .newline) {
+            pos += 1;
+        }
+        if (pos >= tokens.items.len or tokens.items[pos].tag == .eof) break;
+
+        // Parse optional `pub`
+        var is_pub = false;
+        if (tokens.items[pos].tag == .kw_pub) {
+            is_pub = true;
+            pos += 1;
+        }
+
+        // Skip newlines after pub
+        while (pos < tokens.items.len and tokens.items[pos].tag == .newline) {
+            pos += 1;
+        }
+
+        // Expect `fn` or `fun`
+        if (pos >= tokens.items.len or tokens.items[pos].tag != .kw_fun) {
+            pos += 1;
+            continue;
+        }
+        pos += 1;
+
+        // Function name
+        if (pos >= tokens.items.len or tokens.items[pos].tag != .identifier) {
+            pos += 1;
+            continue;
+        }
+        const name = tokens.items[pos].slice(source);
+        pos += 1;
+
+        // Parameter list
+        var params: std.ArrayList(RasmFunction.Param) = .empty;
+        if (pos < tokens.items.len and tokens.items[pos].tag == .l_paren) {
+            pos += 1;
+            while (pos < tokens.items.len and tokens.items[pos].tag != .r_paren) {
+                if (tokens.items[pos].tag == .comma or tokens.items[pos].tag == .newline) {
+                    pos += 1;
+                    continue;
+                }
+                // param_name type
+                if (tokens.items[pos].tag == .identifier) {
+                    const param_name = tokens.items[pos].slice(source);
+                    pos += 1;
+                    var type_name: []const u8 = "int64_t";
+                    if (pos < tokens.items.len and tokens.items[pos].tag == .identifier) {
+                        type_name = mapRunTypeToCType(tokens.items[pos].slice(source));
+                        pos += 1;
+                    }
+                    try params.append(allocator, .{ .name = param_name, .type_name = type_name });
+                } else {
+                    pos += 1;
+                }
+            }
+            if (pos < tokens.items.len and tokens.items[pos].tag == .r_paren) {
+                pos += 1;
+            }
+        }
+
+        // Return type (optional, before opening brace)
+        var return_type: []const u8 = "void";
+        while (pos < tokens.items.len and tokens.items[pos].tag == .newline) {
+            pos += 1;
+        }
+        if (pos < tokens.items.len and tokens.items[pos].tag == .identifier) {
+            return_type = mapRunTypeToCType(tokens.items[pos].slice(source));
+            pos += 1;
+        }
+
+        // Skip to body (opening brace)
+        while (pos < tokens.items.len and tokens.items[pos].tag == .newline) {
+            pos += 1;
+        }
+
+        // Body: everything between { and matching }
+        var body: []const u8 = "";
+        if (pos < tokens.items.len and tokens.items[pos].tag == .l_brace) {
+            const brace_tok = tokens.items[pos];
+            pos += 1;
+            const body_start = if (pos < tokens.items.len) tokens.items[pos].loc.start else brace_tok.loc.end;
+            var depth: u32 = 1;
+            while (pos < tokens.items.len and depth > 0) {
+                if (tokens.items[pos].tag == .l_brace) depth += 1;
+                if (tokens.items[pos].tag == .r_brace) depth -= 1;
+                if (depth > 0) pos += 1;
+            }
+            const body_end = if (pos < tokens.items.len) tokens.items[pos].loc.start else body_start;
+            if (pos < tokens.items.len) pos += 1; // skip }
+            body = source[body_start..body_end];
+        }
+
+        try functions.append(allocator, .{
+            .name = name,
+            .is_pub = is_pub,
+            .params = params,
+            .return_type = return_type,
+            .body = body,
+        });
+    }
+
+    return .{ .functions = functions };
+}
+
+/// Map Run type names to C type names.
+fn mapRunTypeToCType(run_type: []const u8) []const u8 {
+    if (std.mem.eql(u8, run_type, "u64") or std.mem.eql(u8, run_type, "i64") or std.mem.eql(u8, run_type, "int")) return "int64_t";
+    if (std.mem.eql(u8, run_type, "u32") or std.mem.eql(u8, run_type, "i32")) return "int32_t";
+    if (std.mem.eql(u8, run_type, "u16") or std.mem.eql(u8, run_type, "i16")) return "int16_t";
+    if (std.mem.eql(u8, run_type, "u8") or std.mem.eql(u8, run_type, "i8")) return "int8_t";
+    if (std.mem.eql(u8, run_type, "f32")) return "float";
+    if (std.mem.eql(u8, run_type, "f64") or std.mem.eql(u8, run_type, "float")) return "double";
+    if (std.mem.eql(u8, run_type, "bool")) return "bool";
+    return "int64_t";
+}
+
+/// Target architecture for platform selection.
+pub const Arch = enum {
+    x86_64,
+    arm64,
+    other,
+
+    pub fn fromBuiltin() Arch {
+        return switch (@import("builtin").cpu.arch) {
+            .x86_64 => .x86_64,
+            .aarch64 => .arm64,
+            else => .other,
+        };
+    }
+
+    pub fn suffix(self: Arch) []const u8 {
+        return switch (self) {
+            .x86_64 => "_amd64",
+            .arm64 => "_arm64",
+            .other => "",
+        };
+    }
+};
+
+/// Given a base path (e.g., "math/fast_math"), find the best .rasm file.
+/// Platform-specific takes priority over portable.
+pub fn selectRasmFile(allocator: std.mem.Allocator, base_path: []const u8, arch: Arch) !?[]const u8 {
+    // Try platform-specific first
+    const arch_suffix = arch.suffix();
+    if (arch_suffix.len > 0) {
+        const specific = try std.fmt.allocPrint(allocator, "{s}{s}.rasm", .{ base_path, arch_suffix });
+        if (fileExists(specific)) {
+            return specific;
+        }
+        allocator.free(specific);
+    }
+
+    // Fall back to portable
+    const portable = try std.fmt.allocPrint(allocator, "{s}.rasm", .{base_path});
+    if (fileExists(portable)) {
+        return portable;
+    }
+    allocator.free(portable);
+
+    return null;
+}
+
+fn fileExists(path: []const u8) bool {
+    std.fs.cwd().access(path, .{}) catch return false;
+    return true;
+}
+
+/// Generate a GAS-compatible .S assembly file from parsed .rasm functions.
+/// The output includes proper function prologues, bodies, and epilogues.
+pub fn generateGasFile(allocator: std.mem.Allocator, rasm: *const RasmFile, arch: Arch) ![]const u8 {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+    const w = output.writer(allocator);
+
+    // File header
+    try w.print("// Generated from .rasm file\n", .{});
+    try w.print(".text\n\n", .{});
+
+    for (rasm.functions.items) |func| {
+        // Mangle name to match Run calling convention
+        try w.print(".globl run_main__{s}\n", .{func.name});
+        try w.print("run_main__{s}:\n", .{func.name});
+
+        // Platform-specific prologue
+        switch (arch) {
+            .x86_64 => {
+                try w.print("    pushq %rbp\n", .{});
+                try w.print("    movq %rsp, %rbp\n", .{});
+            },
+            .arm64 => {
+                try w.print("    stp x29, x30, [sp, #-16]!\n", .{});
+                try w.print("    mov x29, sp\n", .{});
+            },
+            .other => {},
+        }
+
+        // Body — emit raw assembly instructions, trimming whitespace
+        const trimmed = std.mem.trim(u8, func.body, " \t\n\r");
+        if (trimmed.len > 0) {
+            var lines = std.mem.splitScalar(u8, trimmed, '\n');
+            while (lines.next()) |line| {
+                const tline = std.mem.trim(u8, line, " \t\r");
+                if (tline.len > 0) {
+                    try w.print("    {s}\n", .{tline});
+                }
+            }
+        }
+
+        // Platform-specific epilogue
+        switch (arch) {
+            .x86_64 => {
+                try w.print("    popq %rbp\n", .{});
+                try w.print("    retq\n", .{});
+            },
+            .arm64 => {
+                try w.print("    ldp x29, x30, [sp], #16\n", .{});
+                try w.print("    ret\n", .{});
+            },
+            .other => {
+                try w.print("    ret\n", .{});
+            },
+        }
+        try w.print("\n", .{});
+    }
+
+    return try allocator.dupe(u8, output.items);
+}
+
+/// Discover .rasm files alongside a .run source file.
+/// Returns a list of resolved .rasm file paths (platform-specific takes priority).
+pub fn discoverRasmFiles(allocator: std.mem.Allocator, source_dir: []const u8, arch: Arch) !std.ArrayList([]const u8) {
+    var result: std.ArrayList([]const u8) = .empty;
+
+    var dir = std.fs.cwd().openDir(source_dir, .{ .iterate = true }) catch {
+        return result;
+    };
+    defer dir.close();
+
+    // Collect all .rasm files, then filter by platform priority
+    var rasm_bases: std.ArrayList([]const u8) = .empty;
+    defer rasm_bases.deinit(allocator);
+
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind != .file) continue;
+        const name = entry.name;
+        if (!std.mem.endsWith(u8, name, ".rasm")) continue;
+
+        // Extract base name (strip suffix + .rasm)
+        const stem = name[0 .. name.len - 5]; // strip .rasm
+        const base = stripArchSuffix(stem);
+        // Check if this base is already tracked
+        var found = false;
+        for (rasm_bases.items) |existing| {
+            if (std.mem.eql(u8, existing, base)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            try rasm_bases.append(allocator, base);
+        }
+    }
+
+    // For each base, select the best file
+    for (rasm_bases.items) |base| {
+        const base_path = try std.fs.path.join(allocator, &.{ source_dir, base });
+        defer allocator.free(base_path);
+        if (try selectRasmFile(allocator, base_path, arch)) |path| {
+            try result.append(allocator, path);
+        }
+    }
+
+    return result;
+}
+
+fn stripArchSuffix(name: []const u8) []const u8 {
+    if (std.mem.endsWith(u8, name, "_amd64")) return name[0 .. name.len - 6];
+    if (std.mem.endsWith(u8, name, "_arm64")) return name[0 .. name.len - 6];
+    return name;
+}
+
+// Tests
+
+test "parseRasmFile: simple function" {
+    const source =
+        \\pub fn fast_add(a u64, b u64) u64 {
+        \\    add r0, r0, r1
+        \\}
+    ;
+    var result = try parseRasmFile(std.testing.allocator, source);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.functions.items.len);
+    const func = result.functions.items[0];
+    try std.testing.expectEqualStrings("fast_add", func.name);
+    try std.testing.expect(func.is_pub);
+    try std.testing.expectEqual(@as(usize, 2), func.params.items.len);
+    try std.testing.expectEqualStrings("a", func.params.items[0].name);
+    try std.testing.expectEqualStrings("int64_t", func.params.items[0].type_name);
+    try std.testing.expectEqualStrings("int64_t", func.return_type);
+}
+
+test "parseRasmFile: no params no return" {
+    const source =
+        \\fn nop_func() {
+        \\    nop
+        \\}
+    ;
+    var result = try parseRasmFile(std.testing.allocator, source);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), result.functions.items.len);
+    try std.testing.expectEqualStrings("nop_func", result.functions.items[0].name);
+    try std.testing.expect(!result.functions.items[0].is_pub);
+    try std.testing.expectEqualStrings("void", result.functions.items[0].return_type);
+}
+
+test "generateGasFile: x86_64" {
+    const source =
+        \\pub fn fast_add(a u64, b u64) u64 {
+        \\    add r0, r0, r1
+        \\}
+    ;
+    var rasm = try parseRasmFile(std.testing.allocator, source);
+    defer rasm.deinit(std.testing.allocator);
+
+    const gas = try generateGasFile(std.testing.allocator, &rasm, .x86_64);
+    defer std.testing.allocator.free(gas);
+
+    try std.testing.expect(std.mem.indexOf(u8, gas, "run_main__fast_add:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, gas, "pushq %rbp") != null);
+    try std.testing.expect(std.mem.indexOf(u8, gas, "retq") != null);
+}
+
+test "mapRunTypeToCType" {
+    try std.testing.expectEqualStrings("int64_t", mapRunTypeToCType("u64"));
+    try std.testing.expectEqualStrings("int64_t", mapRunTypeToCType("int"));
+    try std.testing.expectEqualStrings("double", mapRunTypeToCType("f64"));
+    try std.testing.expectEqualStrings("float", mapRunTypeToCType("f32"));
+    try std.testing.expectEqualStrings("bool", mapRunTypeToCType("bool"));
+}
+
+test "Arch: suffix" {
+    try std.testing.expectEqualStrings("_amd64", Arch.x86_64.suffix());
+    try std.testing.expectEqualStrings("_arm64", Arch.arm64.suffix());
+}
+
+test "stripArchSuffix" {
+    try std.testing.expectEqualStrings("fast_math", stripArchSuffix("fast_math_amd64"));
+    try std.testing.expectEqualStrings("fast_math", stripArchSuffix("fast_math_arm64"));
+    try std.testing.expectEqualStrings("fast_math", stripArchSuffix("fast_math"));
+}

--- a/src/resolve.zig
+++ b/src/resolve.zig
@@ -567,6 +567,23 @@ pub const Resolver = struct {
             // Variants
             .variant => try self.resolveNode(self.nodeData(node).lhs),
 
+            // Assembly expressions — resolve input expressions
+            .asm_expr => {
+                const data = self.nodeData(node);
+                const extra = self.tree.extra_data.items;
+                const input_count = extra[data.lhs];
+                var i: u32 = 0;
+                while (i < input_count) : (i += 1) {
+                    const input_node = extra[data.lhs + 1 + i];
+                    // Resolve the expression in the asm_input
+                    const input_data = self.nodeData(input_node);
+                    try self.resolveNode(input_data.lhs);
+                }
+            },
+
+            // These are handled by their parent or contain no resolvable names
+            .asm_input, .asm_body, .asm_simple_body, .asm_platform => {},
+
             // These are handled by their parent
             .fn_decl, .pub_decl, .struct_decl, .interface_decl,
             .type_alias, .type_decl, .package_decl, .import_decl,

--- a/src/root.zig
+++ b/src/root.zig
@@ -26,6 +26,7 @@ pub const lsp = @import("lsp.zig");
 pub const init = @import("init.zig");
 pub const formatter = @import("formatter.zig");
 pub const test_runner = @import("test_runner.zig");
+pub const rasm = @import("rasm.zig");
 
 const std = @import("std");
 

--- a/src/token.zig
+++ b/src/token.zig
@@ -50,6 +50,8 @@ pub const Token = struct {
         kw_and,
         kw_or,
         kw_not,
+        kw_asm,
+        kw_clobber,
 
         // Operators
         plus, // +
@@ -69,10 +71,13 @@ pub const Token = struct {
         ampersand, // &
         at, // @
         arrow_left, // <-
+        arrow_right, // ->
         dot_dot, // ..
         ellipsis, // ...
         dot, // .
         pipe, // |
+        hash, // #
+        semicolon, // ;
 
         // Delimiters
         l_paren, // (
@@ -93,7 +98,7 @@ pub const Token = struct {
 
         pub fn isKeyword(tag: Tag) bool {
             return @intFromEnum(tag) >= @intFromEnum(Tag.kw_fun) and
-                @intFromEnum(tag) <= @intFromEnum(Tag.kw_not);
+                @intFromEnum(tag) <= @intFromEnum(Tag.kw_clobber);
         }
     };
 
@@ -129,6 +134,8 @@ pub const Token = struct {
         .{ "and", .kw_and },
         .{ "or", .kw_or },
         .{ "not", .kw_not },
+        .{ "asm", .kw_asm },
+        .{ "clobber", .kw_clobber },
     });
 
     pub fn getKeyword(bytes: []const u8) ?Tag {


### PR DESCRIPTION
## Summary

- Implements the M7 (Universal Assembly Language) milestone, addressing issues #67, #68, #69, and #70
- Adds inline assembly expression parsing (`asm(expr -> reg) type { ... }`) with input bindings, clobber lists, and platform-conditional sections (`#x86_64 { ... }`, `#arm64 { ... }`)
- Adds full IR-to-C codegen pipeline emitting GCC `__asm__ __volatile__` blocks with proper register constraints
- Adds `.rasm` file support with platform suffix selection (`file_amd64.rasm` takes priority over `file.rasm`) and GAS `.S` file generation
- All existing tests pass, plus new tests for lexer tokens, parser asm syntax, and rasm file handling

## Test plan

- [x] `zig build` compiles without errors
- [x] `zig build test` — all 100+ existing tests pass
- [x] New lexer tests verify `->`, `#`, `;`, `asm`, `clobber` token scanning
- [x] New parser tests verify inline asm with inputs, clobber lists, no-input form, and platform conditionals
- [x] New rasm tests verify .rasm parsing, GAS generation, type mapping, and arch suffix handling

Fixes #67, #68, #69, #70

https://claude.ai/code/session_01F2GNDxAhyggCGC5X8Np5P9