### PR TITLE
Fix Cloudflare deploy by adding assets directory config

### DIFF
--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -2,5 +2,8 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "runlang",
   "pages_build_output_dir": "dist",
-  "compatibility_date": "2025-04-01"
+  "compatibility_date": "2025-04-01",
+  "assets": {
+    "directory": "./dist"
+  }
 }


### PR DESCRIPTION
The deploy command `wrangler deploy` (Workers) requires an `assets`
directive to locate static files. The existing `pages_build_output_dir`
is only used by `wrangler pages deploy`.

https://claude.ai/code/session_01NNknb7CWvTWuaNdMnD8xDx