### PR TITLE
Fix website styling by importing Tailwind CSS

### DIFF
--- a/website/src/layouts/Landing.astro
+++ b/website/src/layouts/Landing.astro
@@ -1,4 +1,6 @@
 ---
+import "../styles/custom.css";
+
 interface Props {
   title?: string;
   description?: string;


### PR DESCRIPTION
The Landing.astro layout was missing CSS imports, causing the landing page and playground to render completely unstyled. Added the custom.css import which brings in Tailwind CSS configuration and theme variables, fixing the broken styling.