### PR TITLE
Fix struct declaration syntax in docs to match spec

### DIFF
--- a/.claude/agents/lang-designer.md
+++ b/.claude/agents/lang-designer.md
@@ -24,7 +24,7 @@ You design and verify the semantic rules of Run. You specify how name resolution
 - String: `string` (UTF-8 byte slice)
 
 ### Composite Types
-- **Structs**: `Name struct { fields }` — name before keyword, data only (no methods inside)
+- **Structs**: `type Name struct { fields }` — name before keyword, data only (no methods inside)
 - **Interfaces**: `interface Name { method_sigs }` — explicit, with `implements` block in structs
 - **Sum types**: `type State = .loading | .ready(Data) | .error(string)` — tagged unions with pattern matching
 - **Nullable**: `T?` — must handle null explicitly via switch

--- a/.claude/agents/stdlib-designer.md
+++ b/.claude/agents/stdlib-designer.md
@@ -63,7 +63,7 @@ pub fun open(path string) !File {
 }
 
 // Struct with interface
-pub File struct {
+pub type File struct {
     implements {
         io.Reader
         io.Writer
@@ -141,7 +141,7 @@ pub interface ReadWriter {
 }
 
 // Buffered wrapper
-pub BufferedReader struct {
+pub type BufferedReader struct {
     implements { Reader }
     // ...
 }
@@ -164,7 +164,7 @@ pub fun args() []string
 
 ### testing Module
 ```run
-pub Testing struct {
+pub type Testing struct {
     // test context
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ These differ from older Zig versions and are critical to get right:
 - No generics by design
 - `&T` (read/write pointer), `@T` (read-only pointer)
 - `!T` error unions with `try` and `switch`
-- Structs use `Name struct { }` syntax (name before keyword); interfaces with `implements` block inside struct
-- Go-style methods: `fn (recv &Type) name(params) ret { body }` — receiver in parens between `fn` and method name
+- Structs use `type Name struct { }` syntax (name before keyword); interfaces with `implements` block inside struct
+- Go-style methods: `fun (recv &Type) name(params) ret { body }` — receiver in parens between `fun` and method name
 - Newlines are significant tokens
 
 ## Current Status

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run targets developers who want memory safety, performance, and straightforward 
 ## A Quick Look
 
 ```run
-pub Point struct {
+pub type Point struct {
     x f64
     y f64
 }

--- a/docs/stdlib/design.md
+++ b/docs/stdlib/design.md
@@ -130,7 +130,7 @@ type FileError = .notFound
     | .notDirectory
     | .diskFull
 
-pub File struct {
+pub type File struct {
     implements {
         io.Reader
         io.Writer


### PR DESCRIPTION
All struct declarations should use `pub type Name struct { }` syntax (with the `type` keyword), not `pub Name struct { }`. Also fix `fn` → `fun` in CLAUDE.md method syntax description.

Files fixed:
- README.md: `pub Point struct` → `pub type Point struct`
- CLAUDE.md: `Name struct` → `type Name struct`, `fn` → `fun`
- docs/stdlib/design.md: `pub File struct` → `pub type File struct`
- .claude/agents/stdlib-designer.md: File, BufferedReader, Testing structs
- .claude/agents/lang-designer.md: syntax description

https://claude.ai/code/session_01QLJwmWvTvZmVdXgZHbHyhX