### PR TITLE
Refine website copy toward pragmatic tone

### DIFF
--- a/website/src/components/landing/Features.astro
+++ b/website/src/components/landing/Features.astro
@@ -37,7 +37,7 @@ const features = [
   <div class="mx-auto max-w-7xl px-6">
     <div class="mb-12 text-center">
       <h2 class="mb-4 text-3xl font-bold text-white">Why Run?</h2>
-      <p class="text-lg text-gray-400">The tools you need for systems programming, without the complexity.</p>
+      <p class="text-lg text-gray-400">Powerful tools, none of the complexity.</p>
     </div>
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {features.map((feature) => (

--- a/website/src/components/landing/Footer.astro
+++ b/website/src/components/landing/Footer.astro
@@ -7,7 +7,7 @@
       <div>
         <h3 class="mb-3 text-lg font-bold text-white">Run</h3>
         <p class="text-sm leading-relaxed text-gray-400">
-          A systems programming language combining Go's simplicity with low-level control.
+          The fun way to solve hard problems.
         </p>
       </div>
       <div>

--- a/website/src/components/landing/Hero.astro
+++ b/website/src/components/landing/Hero.astro
@@ -13,14 +13,14 @@
           Active Development
         </div>
         <h1 class="mb-6 text-3xl leading-tight font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
-          Go's simplicity meets<br />
+          The fun way to solve<br />
           <span class="inline-block bg-gradient-to-r from-run-primary to-run-accent bg-clip-text pb-1 text-transparent">
-            systems-level control
+            hard problems
           </span>
         </h1>
         <p class="mb-8 max-w-xl text-lg leading-relaxed text-gray-400">
-          Memory safety without a garbage collector or borrow checker. Generational references,
-          green threads, and a type system that stays out of your way.
+          Systems-level power with none of the ceremony. Memory safety, green threads,
+          and a type system that stays out of your way — so you can focus on what matters.
         </p>
         <div class="flex flex-wrap gap-4">
           <a

--- a/website/src/layouts/Landing.astro
+++ b/website/src/layouts/Landing.astro
@@ -7,8 +7,8 @@ interface Props {
 }
 
 const {
-  title = "Run — Systems programming with Go's simplicity",
-  description = "A systems programming language combining Go's simplicity with low-level control. Memory safety without a garbage collector or borrow checker.",
+  title = "Run — The fun way to solve hard problems",
+  description = "A fun programming language for solving hard problems. Memory safety, green threads, and systems-level control without the complexity.",
 } = Astro.props;
 ---
 


### PR DESCRIPTION
## Summary
Updated landing page copy to emphasize Run's practical appeal rather than pure systems programming focus. Hero headline now reads "The fun way to solve hard problems" with supporting messaging that highlights systems-level power without the ceremony.

## Changes
- Hero headline: "Go's simplicity meets systems-level control" → "The fun way to solve hard problems"
- Hero subheading: Reframed to lead with value proposition
- Page title/meta description: Updated to match new messaging
- Footer tagline: Consistent with hero messaging
- Features section: Simplified subheading for clarity

Messaging maintains technical accuracy while being more accessible to non-systems-programming audiences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)