### PR TITLE
Split RFC #218: Package Manager into 30 granular issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,14 @@ The milestones are ordered by dependency — each builds on the previous:
 7. **M7: Universal Assembly Language** — Portable assembly syntax, inline asm blocks, platform-specific asm files, assembler integration with C codegen
 8. **M8: Native SIMD** — First-class vector types (`v4f32`, `v8i32`, etc.), SIMD operations, auto-vectorization hints, platform-specific intrinsic mapping
 9. **M9: NUMA-Aware Runtime** — Topology discovery, NUMA-aware allocators, thread/green-thread affinity, memory placement policies
+10. **M10: Stdlib Foundation** — Core stdlib packages (fmt, io, os, strings, bytes, unicode)
+11. **M11: Stdlib Utilities** — Utility stdlib packages (math, sort, hash, encoding, compress, crypto)
+12. **M12: Stdlib Application** — Application-level stdlib packages (net, http, json, testing, log, time)
+13. **M13: Stdlib Specialized** — Specialized stdlib packages (reflect, debug, plugin, unsafe)
+14. **M14: Package Manager Core** — TOML manifest, semver resolution, GitHub fetching, local cache, MVS dependency resolution, `run get`/`run mod` CLI commands
+15. **M15: Package Manager Integration** — External import resolution, scope-aware dependency checking, multi-module compilation, vendor mode, offline builds, private repo auth
 
-M7 is the foundation (assembly provides the low-level escape hatch). M8 and M9 can proceed in parallel after M7.
+M7 is the foundation (assembly provides the low-level escape hatch). M8 and M9 can proceed in parallel after M7. M10-M13 expand the stdlib from M4's core. M14 depends on M5 (Tooling). M15 depends on M14. See RFC #218 for the full package manager design.
 
 ### Long-term Goal: Self-Hosted Compiler (#188)
 
@@ -88,7 +94,7 @@ Once the compiler and language are stable enough (post-M6 at minimum), the compi
 
 ### Labels
 
-Component labels for categorizing issues: `type-system`, `runtime`, `stdlib`, `tooling`, `compiler`, `concurrency`, `memory`, `testing`, `assembly`, `simd`, `numa`
+Component labels for categorizing issues: `type-system`, `runtime`, `stdlib`, `tooling`, `compiler`, `concurrency`, `memory`, `testing`, `assembly`, `simd`, `numa`, `package-manager`
 
 ## Website
 


### PR DESCRIPTION
## Summary

Implements RFC #218 (Package Manager Design) by creating two new milestones (M14, M15) and 30 granular issues across six implementation phases. Updates the development roadmap in CLAUDE.md to include stdlib expansion (M10-M13) and package manager work.

**Milestones:**
- **M14: Package Manager Core** (19 issues) — Phases 1-4: TOML parsing, semver, GitHub fetching, MVS resolution, CLI commands
- **M15: Package Manager Integration** (11 issues) — Phases 5-6: Compiler integration, multi-module compilation, vendor mode, offline builds, private repo auth

**Issues Created:** #293-#322 (30 total)

**Related Issues Closed:**
- #221 (aliased imports) via Issue #318
- #223 (monorepo sub-modules) via Issue #322
- #225 (run.toml migration) via Issue #298

## Changes

- Added M10-M13 (stdlib package expansion) and M14-M15 (package manager) to the Development Roadmap
- Documented milestone dependencies and relationships
- Added `package-manager` label for filtering related issues
- Created the `package-manager` GitHub label

🤖 Generated with [Claude Code](https://claude.ai/code)