### PR TITLE
Add 16 new stdlib packages and update APIs (RFC #219)

### DIFF
--- a/docs/stdlib/packages.md
+++ b/docs/stdlib/packages.md
@@ -16,10 +16,10 @@ This document defines the complete set of standard library packages for Run, the
 
 | Tier | Meaning | Milestone |
 |------|---------|-----------|
-| **P0** | Core — everything depends on these | M4 |
-| **P1** | Essential utilities — needed by most programs | M4 |
-| **P2** | Important ecosystem — needed for real applications | M4 |
-| **P3** | Advanced/specialized — systems programming power | M7–M9 |
+| **P0** | Core — everything depends on these | M10 |
+| **P1** | Essential utilities — needed by most programs | M11 |
+| **P2** | Important ecosystem — needed for real applications | M12 |
+| **P3** | Advanced/specialized — systems programming power | M13 |
 
 ---
 
@@ -140,6 +140,31 @@ user_home_dir() !string        — user home directory
 ```
 
 **Dependencies:** `io`
+**Status:** Stub exists
+
+---
+
+### `errors` — Error Creation, Wrapping, Inspection
+
+**Purpose:** Create, wrap, and inspect error chains. Run has `!T` error unions but needs a standard way to build and traverse error values.
+
+**Key types and functions:**
+```
+Error             interface    — message() string
+Wrapper           interface    — unwrap() Error?
+SimpleError       struct       — basic error with message string
+WrappedError      struct       — error that wraps another with context
+
+new(msg string) Error                     — create a simple error
+wrap(err Error, msg string) Error         — wrap error with context
+wrap_f(err Error, fmt string, args...) Error — wrap with formatted context
+unwrap(err Error) Error?                  — get inner error
+is(err Error, target Error) bool          — walk chain checking match
+as(err Error, target &any) bool           — type-narrow within chain
+join(errs []Error) Error?                 — combine multiple errors
+```
+
+**Dependencies:** None (leaf package)
 **Status:** Stub exists
 
 ---
@@ -423,6 +448,164 @@ JsonHandler       struct       — structured JSON output
 ```
 
 **Dependencies:** `io`, `time`, `fmt`
+
+---
+
+### `iter` — Iterator Protocol and Combinators
+
+**Purpose:** Lazy iteration abstraction with functional combinators. Uses `any` types; see `run gen` for type-safe specializations.
+
+**Key types and functions:**
+```
+Iterator          interface    — next() any?
+
+from_slice(s []any) Iterator              — iterate over slice elements
+range(start, end int) Iterator            — iterate over integer range
+map(it Iterator, f fun(any) any) Iterator — apply f to each element
+filter(it Iterator, f fun(any) bool) Iterator — yield only matching elements
+reduce(it Iterator, init any, f fun(acc, item any) any) any — fold
+take(it Iterator, n int) Iterator         — yield at most n elements
+skip(it Iterator, n int) Iterator         — skip first n elements
+zip(a, b Iterator) Iterator              — combine element-wise
+chain(a, b Iterator) Iterator            — concatenate sequentially
+enumerate(it Iterator) Iterator          — yield (index, item) pairs
+collect(it Iterator) []any               — consume into slice
+count(it Iterator) int                   — count remaining elements
+any_match(it Iterator, f fun(any) bool) bool — true if any match
+all_match(it Iterator, f fun(any) bool) bool — true if all match
+for_each(it Iterator, f fun(any))        — apply f for side effects
+flat_map(it Iterator, f fun(any) Iterator) Iterator — map and flatten
+take_while(it Iterator, f fun(any) bool) Iterator
+skip_while(it Iterator, f fun(any) bool) Iterator
+```
+
+**Dependencies:** None
+**Status:** Stub exists
+
+---
+
+### `slices` — Slice Utilities
+
+**Purpose:** Common operations on slices: search, sort, transform, compare.
+
+**Key types and functions:**
+```
+contains(s []any, v any) bool             — membership test
+index(s []any, v any) int?               — first index of v
+last_index(s []any, v any) int?          — last index of v
+compact(s []any) []any                   — remove consecutive duplicates
+sort_func(s []any, cmp fun(a, b any) int) — sort in-place
+is_sorted_func(s []any, cmp fun(a, b any) int) bool
+reverse(s []any)                         — reverse in place
+grow(s []any, n int) []any               — increase capacity
+insert(s []any, i int, v any) []any      — insert at index
+delete(s []any, i int) []any             — remove at index
+clone(s []any) []any                     — shallow copy
+equal(a, b []any) bool                   — element-wise equality
+min_func(s []any, cmp fun) any           — minimum by comparator
+max_func(s []any, cmp fun) any           — maximum by comparator
+binary_search_func(s []any, target any, cmp fun) int?
+chunk(s []any, size int) [][]any         — split into chunks
+concat(slices [][]any) []any             — concatenate slices
+```
+
+**Dependencies:** None
+**Status:** Stub exists
+
+---
+
+### `maps` — Map Utilities
+
+**Purpose:** Common operations on maps: key/value extraction, comparison, copying.
+
+**Key types and functions:**
+```
+keys(m map[any]any) []any                — all keys as slice
+values(m map[any]any) []any              — all values as slice
+clone(m map[any]any) map[any]any         — shallow copy
+equal(a, b map[any]any) bool             — key/value equality
+equal_func(a, b map[any]any, eq fun) bool — equality with custom comparator
+delete_func(m map[any]any, f fun(key, value any) bool) — conditional delete
+copy(dst, src map[any]any)               — copy all entries from src to dst
+has(m map[any]any, key any) bool         — key membership test
+```
+
+**Dependencies:** None
+**Status:** Stub exists
+
+---
+
+### `cmp` — Comparison and Ordering
+
+**Purpose:** Comparison interfaces and ordering utilities.
+
+**Key types and functions:**
+```
+Ordering          sum type     — .less | .equal | .greater
+Ordered           interface    — compare(other any) Ordering
+
+compare(a, b any) Ordering               — generic comparison
+min(a, b any) any                        — smaller of two values
+max(a, b any) any                        — larger of two values
+clamp(val, lo, hi any) any               — constrain to range
+min_int(a, b int) int                    — integer min
+max_int(a, b int) int                    — integer max
+clamp_int(val, lo, hi int) int           — integer clamp
+min_float(a, b f64) f64                  — float min
+max_float(a, b f64) f64                  — float max
+```
+
+**Dependencies:** None
+**Status:** Stub exists
+
+---
+
+### `math/bits` — Bit Manipulation
+
+**Purpose:** Bit counting, rotation, reversal, and extended arithmetic operations.
+
+**Key types and functions:**
+```
+leading_zeros(x int) int                 — count leading zeros
+trailing_zeros(x int) int               — count trailing zeros
+ones_count(x int) int                   — population count
+rotate_left(x int, k int) int           — rotate left by k bits
+rotate_right(x int, k int) int          — rotate right by k bits
+reverse(x int) int                      — reverse bit order
+reverse_bytes(x int) int                — byte swap
+len(x int) int                          — bit length
+add(x, y, carry int) int               — extended add with carry
+sub(x, y, borrow int) int              — extended sub with borrow
+mul(x, y int) int                      — full-width multiply
+leading_zeros32(x int) int             — 32-bit leading zeros
+trailing_zeros32(x int) int            — 32-bit trailing zeros
+ones_count32(x int) int                — 32-bit popcount
+```
+
+**Dependencies:** None
+**Status:** Stub exists
+
+---
+
+### `path` — OS-Independent Path Manipulation
+
+**Purpose:** Clean path manipulation using forward slashes, independent of OS. For OS-specific paths use `os` package path functions.
+
+**Key types and functions:**
+```
+join(parts ...string) string             — join path elements
+base(p string) string                    — last path element
+dir(p string) string                     — all but last element
+ext(p string) string                     — file extension
+clean(p string) string                   — shortest equivalent path
+is_abs(p string) bool                    — absolute path check
+split(p string) string                   — directory + file components
+match(pattern, name string) !bool        — shell pattern match
+rel(base, target string) !string         — relative path
+```
+
+**Dependencies:** None
+**Status:** Stub exists
 
 ---
 
@@ -1626,6 +1809,249 @@ reset(signals ...Signal)                   — reset to default behavior
 
 ---
 
+### `encoding/toml` — TOML Parsing and Serialization
+
+**Purpose:** Parse and generate TOML configuration files. Required by the package manager (`run.toml`).
+
+**Key types and functions:**
+```
+TomlError         sum type     — .syntax_error | .type_mismatch | .duplicate_key | .invalid_datetime | .mixed_array
+Value             sum type     — .string | .int | .float | .bool | .datetime | .array | .table
+
+parse(data string) !Value                — parse TOML string to Value tree
+parse_file(path string) !Value           — read and parse TOML file
+marshal(value any) !string               — encode to TOML string
+unmarshal(data string, target &any) !void — decode into target
+
+(v Value) get(key string) Value?         — lookup by key
+(v Value) get_string(key string) string? — get string value
+(v Value) get_int(key string) int?       — get integer value
+(v Value) get_bool(key string) bool?     — get boolean value
+(v Value) get_table(key string) Value?   — get table value
+(v Value) get_array(key string) []Value? — get array value
+
+Encoder           struct       — streaming TOML encoder
+Decoder           struct       — streaming TOML decoder
+```
+
+**Dependencies:** `io`
+**Status:** Stub exists
+
+---
+
+### `encoding/yaml` — YAML Parsing and Serialization
+
+**Purpose:** Parse and generate YAML, the most common configuration format (Kubernetes, CI/CD, Docker Compose).
+
+**Key types and functions:**
+```
+YamlError         sum type     — .syntax_error | .duplicate_key | .invalid_anchor | .circular_reference | .type_mismatch | .unsupported_tag
+Value             sum type     — .null | .bool | .int | .float | .string | .sequence | .mapping
+
+marshal(value any) ![]byte              — encode to YAML bytes
+unmarshal(data []byte, target &any) !void — decode YAML bytes
+marshal_string(value any) !string       — encode to YAML string
+parse(data []byte) !Value               — parse to Value tree
+parse_string(s string) !Value           — parse string to Value tree
+
+(v Value) get(key string) Value?        — lookup by key
+(v Value) index(i int) Value?           — lookup by index in sequence
+(v Value) as_string() string?           — extract string value
+(v Value) as_int() int?                 — extract int value
+(v Value) as_float() f64?              — extract float value
+(v Value) as_bool() bool?              — extract bool value
+(v Value) as_sequence() []Value?       — extract sequence
+(v Value) as_mapping() map[string]Value? — extract mapping
+
+Encoder           struct       — streaming YAML encoder
+Decoder           struct       — streaming YAML decoder (multi-document)
+```
+
+**Dependencies:** `io`
+**Status:** Stub exists
+
+---
+
+### `encoding/xml` — XML Parsing and Serialization
+
+**Purpose:** XML encoding/decoding with streaming token-based and tree-based APIs.
+
+**Key types and functions:**
+```
+XmlError          sum type     — .syntax_error | .unexpected_eof | .invalid_character | .unclosed_tag | .mismatched_tag
+Token             sum type     — .start_element | .end_element | .char_data | .comment | .proc_inst | .directive
+
+Name              struct       — local string, space string
+Attr              struct       — name Name, value string
+StartElement      struct       — name Name, attr []Attr
+EndElement        struct       — name Name
+ProcInst          struct       — target string, inst string
+
+marshal(v any) ![]byte                  — encode to XML
+marshal_indent(v any, prefix, indent string) ![]byte
+unmarshal(data []byte, target &any) !void — decode XML
+
+Encoder           struct       — streaming XML encoder
+Decoder           struct       — streaming XML decoder
+(d Decoder) token() !Token?            — read next token
+(d Decoder) decode(target &any) !void  — decode element
+(d Decoder) skip() !void              — skip current element
+```
+
+**Dependencies:** `io`
+**Status:** Stub exists
+
+---
+
+### `compress/zstd` — Zstandard Compression
+
+**Purpose:** Modern, fast compression with better ratios than gzip at comparable speeds.
+
+**Key types and functions:**
+```
+ZstdError         sum type     — .corrupt_input | .window_too_large | .dictionary_mismatch | .unexpected_eof
+
+compress(data []byte) ![]byte           — compress with default level
+compress_level(data []byte, level int) ![]byte — compress with specific level (1-19)
+decompress(data []byte) ![]byte         — decompress
+
+Reader            struct       — streaming decompressor (io.Reader + io.Closer)
+Writer            struct       — streaming compressor (io.Writer + io.Closer)
+new_reader(r io.Reader) !Reader
+new_writer(w io.Writer) Writer
+new_writer_level(w io.Writer, level int) !Writer
+```
+
+**Dependencies:** `io`
+**Status:** Stub exists
+
+---
+
+### `io/fs` — Virtual Filesystem Interface
+
+**Purpose:** Abstract filesystem interface for testable I/O, embedded files, and archive access.
+
+**Key types and functions:**
+```
+FsError           sum type     — .not_found | .permission_denied | .not_directory | .invalid_path
+FileMode          sum type     — .regular | .directory | .symlink | .socket | .pipe | .device
+
+FS                interface    — open(name string) !File
+File              interface    — stat() !FileInfo, read(buf) !int, close() !void
+ReadDirFS         interface    — FS + read_dir(name string) ![]DirEntry
+StatFS            interface    — FS + stat(name string) !FileInfo
+FileInfo          interface    — name, size, mode, mod_time, is_dir
+DirEntry          interface    — name, is_dir, type_mode, info
+
+walk_dir(fsys FS, root string, fn fun(path, d, err))
+sub(fsys FS, dir string) !FS
+glob(fsys FS, pattern string) ![]string
+read_file(fsys FS, name string) ![]byte
+valid_path(name string) bool
+```
+
+**Dependencies:** `io`
+**Status:** Stub exists
+
+---
+
+### `html` — HTML Escaping
+
+**Purpose:** Security-critical HTML entity escaping and unescaping to prevent XSS attacks.
+
+**Key types and functions:**
+```
+escape_string(s string) string           — < > & " ' → entities
+unescape_string(s string) string         — entities → characters
+```
+
+**Dependencies:** None
+**Status:** Stub exists
+
+---
+
+### `text/template` — Text Templating
+
+**Purpose:** Data-driven text templates with field access, conditionals, iteration, and pipelines.
+
+**Key types and functions:**
+```
+TemplateError     sum type     — .parse_error | .exec_error | .undefined_variable | .undefined_function | .wrong_arg_count
+
+Template          struct       — compiled template
+
+new(name string) Template
+parse(text string) !Template
+parse_files(filenames ...string) !Template
+must(t Template) Template
+
+(t Template) execute(wr io.Writer, data any) !void
+(t Template) execute_string(data any) !string
+(t Template) name() string
+```
+
+**Dependencies:** `io`
+**Status:** Stub exists
+
+---
+
+### `hash/crc32` — CRC-32
+
+**Purpose:** CRC-32 checksum computation with IEEE, Castagnoli, and Koopman polynomials.
+
+**Key types and functions:**
+```
+Table             struct       — precomputed polynomial table
+
+make_table(poly int) Table              — build table from polynomial
+new(tab Table) hash.Hash32              — new Hash32 using table
+checksum(data []byte, tab Table) int    — compute CRC-32
+checksum_ieee(data []byte) int          — CRC-32 with IEEE polynomial
+update(crc int, tab Table, data []byte) int — update running CRC
+```
+
+**Dependencies:** `hash`
+**Status:** Stub exists
+
+---
+
+### `hash/fnv` — FNV Hash
+
+**Purpose:** FNV-1 and FNV-1a hash functions in 32, 64, and 128-bit variants.
+
+**Key types and functions:**
+```
+new32() hash.Hash32                     — FNV-1 32-bit
+new32a() hash.Hash32                    — FNV-1a 32-bit
+new64() hash.Hash64                     — FNV-1 64-bit
+new64a() hash.Hash64                    — FNV-1a 64-bit
+new128() hash.Hash64                    — FNV-1 128-bit
+new128a() hash.Hash64                   — FNV-1a 128-bit
+```
+
+**Dependencies:** `hash`
+**Status:** Stub exists
+
+---
+
+### `crypto/subtle` — Constant-Time Operations
+
+**Purpose:** Constant-time operations for avoiding timing side-channel attacks in cryptographic code.
+
+**Key types and functions:**
+```
+constant_time_compare(a, b []byte) bool — constant-time byte comparison
+constant_time_eq(a, b int) bool         — constant-time integer equality
+constant_time_select(v, a, b int) int   — constant-time conditional select
+constant_time_copy(v int, dst, src []byte) — conditional copy
+xor_bytes(dst, a, b []byte) int         — XOR byte slices
+```
+
+**Dependencies:** None
+**Status:** Stub exists
+
+---
+
 ## P3 — Advanced/Specialized Packages
 
 ### `simd` — SIMD Vector Operations
@@ -1912,10 +2338,12 @@ yield()                        — yield current green thread to scheduler
 | `io` | I/O interfaces, buffered I/O, utilities | P0 | — |
 | `fmt` | Formatting and printing | P0 | `io` |
 | `os` | Files, processes, env, paths | P0 | `io` |
+| `errors` | Error creation, wrapping, inspection | P0 | — |
 | `strings` | String manipulation | P1 | — |
 | `bytes` | Byte slice utilities, Buffer | P1 | `io` |
 | `math` | Math functions and constants | P1 | — |
 | `math/rand` | Pseudo-random numbers | P1 | `math` |
+| `math/bits` | Bit counting, rotation, extended arithmetic | P1 | — |
 | `testing` | Test framework and assertions | P1 | `fmt`, `strings` |
 | `time` | Time, duration, timers | P1 | — |
 | `log` | Structured logging | P1 | `io`, `time`, `fmt` |
@@ -1924,6 +2352,11 @@ yield()                        — yield current green thread to scheduler
 | `unicode/utf8` | UTF-8 encoding/decoding | P1 | — |
 | `sort` | Sorting algorithms | P1 | — |
 | `bufio` | Scanner, line-by-line reading | P1 | `io`, `bytes` |
+| `iter` | Iterator protocol and combinators | P1 | — |
+| `slices` | Slice utilities | P1 | — |
+| `maps` | Map utilities | P1 | — |
+| `cmp` | Comparison and ordering | P1 | — |
+| `path` | OS-independent path manipulation | P1 | — |
 | `net` | TCP/UDP, DNS | P2 | `io`, `time`, `os` |
 | `net/http` | HTTP client and server | P2 | `net`, `io`, `fmt`, `strings`, `time`, `context`, `metrics` |
 | `net/http2` | HTTP/2 protocol | P2 | `net`, `net/http`, `io`, `sync`, `crypto/tls` |
@@ -1933,12 +2366,16 @@ yield()                        — yield current green thread to scheduler
 | `encoding/csv` | CSV read/write | P2 | `io`, `strings`, `bytes` |
 | `encoding/base64` | Base64 encode/decode | P2 | — |
 | `encoding/hex` | Hex encode/decode | P2 | `bytes` |
-| `crypto` | Hash interface, secure random | P2 | `io` |
+| `encoding/toml` | TOML parsing and serialization | P2 | `io` |
+| `encoding/yaml` | YAML parsing and serialization | P2 | `io` |
+| `encoding/xml` | XML parsing and serialization | P2 | `io` |
+| `crypto` | Hash/AEAD/signing interfaces, recommended defaults | P2 | `io` |
 | `crypto/sha256` | SHA-256 | P2 | `crypto` |
 | `crypto/sha512` | SHA-512 | P2 | `crypto` |
 | `crypto/hmac` | HMAC | P2 | `crypto` |
 | `crypto/aes` | AES block cipher | P2 | `crypto` |
 | `crypto/tls` | TLS connections | P2 | `crypto/*`, `net`, `io` |
+| `crypto/subtle` | Constant-time operations | P2 | — |
 | `sync` | Mutex, RwMutex, WaitGroup, Atomic | P2 | — |
 | `unsafe` | Raw pointers, type layout | P2 | — |
 | `context` | Cancellation and deadlines | P2 | `time` |
@@ -1950,11 +2387,17 @@ yield()                        — yield current green thread to scheduler
 | `os/signal` | OS signal handling | P2 | `os` |
 | `regex` | Regular expressions | P2 | `strings` |
 | `hash` | Non-crypto hash functions | P2 | — |
+| `hash/crc32` | CRC-32 checksums | P2 | `hash` |
+| `hash/fnv` | FNV hash functions | P2 | `hash` |
 | `compress/flate` | DEFLATE compression | P2 | `io` |
 | `compress/gzip` | Gzip compression | P2 | `io`, `compress/flate` |
 | `compress/zlib` | Zlib compression | P2 | `io`, `compress/flate` |
+| `compress/zstd` | Zstandard compression | P2 | `io` |
 | `archive/tar` | Tar archives | P2 | `io`, `os`, `time` |
 | `archive/zip` | Zip archives | P2 | `io`, `os`, `compress/flate`, `time` |
+| `io/fs` | Virtual filesystem interface | P2 | `io` |
+| `html` | HTML escaping | P2 | — |
+| `text/template` | Text templating | P2 | `io` |
 | `simd` | SIMD vector operations | P3 | — |
 | `numa` | NUMA topology and allocation | P3 | `os`, `unsafe` |
 | `asm` | Assembly utilities, CPU features | P3 | `unsafe` |
@@ -1962,4 +2405,4 @@ yield()                        — yield current green thread to scheduler
 | `debug` | Stack traces, assertions | P3 | `fmt`, `os` |
 | `runtime` | Runtime introspection | P3 | — |
 
-**Total: 50 packages** (6 exist as stubs)
+**Total: 67 packages**

--- a/stdlib/cmp/cmp.run
+++ b/stdlib/cmp/cmp.run
@@ -1,0 +1,76 @@
+package cmp
+
+// Ordering represents the result of a comparison.
+pub type Ordering = .less | .equal | .greater
+
+// Ordered is the interface for types that have a natural ordering.
+pub type Ordered interface {
+    // compare compares the receiver with other and returns an Ordering.
+    compare(other any) Ordering
+}
+
+// compare compares two values and returns an Ordering.
+pub fun compare(a any, b any) Ordering {
+    return .equal
+}
+
+// min returns the smaller of a or b.
+// If equal, returns a.
+pub fun min(a any, b any) any {
+    return a
+}
+
+// max returns the larger of a or b.
+// If equal, returns a.
+pub fun max(a any, b any) any {
+    return a
+}
+
+// clamp returns val constrained to the range [lo, hi].
+// Panics if lo > hi.
+pub fun clamp(val any, lo any, hi any) any {
+    return val
+}
+
+// min_int returns the smaller of a or b.
+pub fun min_int(a int, b int) int {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+// max_int returns the larger of a or b.
+pub fun max_int(a int, b int) int {
+    if a > b {
+        return a
+    }
+    return b
+}
+
+// clamp_int returns val constrained to the range [lo, hi].
+pub fun clamp_int(val int, lo int, hi int) int {
+    if val < lo {
+        return lo
+    }
+    if val > hi {
+        return hi
+    }
+    return val
+}
+
+// min_float returns the smaller of a or b.
+pub fun min_float(a f64, b f64) f64 {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+// max_float returns the larger of a or b.
+pub fun max_float(a f64, b f64) f64 {
+    if a > b {
+        return a
+    }
+    return b
+}

--- a/stdlib/compress/zstd/zstd.run
+++ b/stdlib/compress/zstd/zstd.run
@@ -1,0 +1,89 @@
+package zstd
+
+use "io"
+
+// ZstdError represents errors during Zstandard compression/decompression.
+pub type ZstdError = .corrupt_input
+    | .window_too_large
+    | .dictionary_mismatch
+    | .unexpected_eof
+
+// Compression level constants.
+pub let default_compression = 3
+pub let best_speed = 1
+pub let best_compression = 19
+
+// compress compresses data using the default compression level.
+pub fun compress(data []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// compress_level compresses data using the specified compression level.
+// Level must be between 1 (fastest) and 19 (best compression).
+pub fun compress_level(data []byte, level int) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// decompress decompresses Zstandard-compressed data.
+pub fun decompress(data []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// Reader reads and decompresses Zstandard data from an underlying reader.
+pub Reader struct {
+    implements {
+        io.Reader
+        io.Closer
+    }
+
+    reader io.Reader
+}
+
+// new_reader returns a new Reader that decompresses data from r.
+pub fun new_reader(r io.Reader) !Reader {
+    return Reader{ reader: r }
+}
+
+// read reads decompressed data into buf.
+pub fun (r &Reader) read(buf []byte) !int {
+    return 0
+}
+
+// close releases resources used by the Reader.
+pub fun (r &Reader) close() !void {
+}
+
+// Writer compresses data and writes to an underlying writer.
+pub Writer struct {
+    implements {
+        io.Writer
+        io.Closer
+    }
+
+    writer io.Writer
+    level  int
+}
+
+// new_writer returns a new Writer that compresses at the default level.
+pub fun new_writer(w io.Writer) Writer {
+    return Writer{ writer: w, level: 3 }
+}
+
+// new_writer_level returns a new Writer that compresses at the given level.
+// Level must be between 1 and 19.
+pub fun new_writer_level(w io.Writer, level int) !Writer {
+    return Writer{ writer: w, level: level }
+}
+
+// write compresses data from buf and writes to the underlying writer.
+pub fun (w &Writer) write(buf []byte) !int {
+    return 0
+}
+
+// flush flushes any pending compressed data to the underlying writer.
+pub fun (w &Writer) flush() !void {
+}
+
+// close finishes the compressed stream and closes the writer.
+pub fun (w &Writer) close() !void {
+}

--- a/stdlib/crypto/crypto.run
+++ b/stdlib/crypto/crypto.run
@@ -75,3 +75,46 @@ pub type CryptoError = .invalidKey
     | .shortBuffer
     | .randomFailure
     | .invalidParameter
+
+// --- Recommended Defaults ---
+// These convenience functions use opinionated, modern algorithms.
+// For specific algorithm control, use the sub-packages directly.
+
+// hash computes a cryptographic hash of data using BLAKE3.
+pub fun hash(data []byte) []byte {
+    return alloc([]byte, 0)
+}
+
+// encrypt encrypts plaintext using ChaCha20-Poly1305 AEAD.
+// Key must be 32 bytes. Returns nonce prepended to ciphertext.
+pub fun encrypt(key []byte, plaintext []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// decrypt decrypts ciphertext produced by encrypt.
+// Key must be 32 bytes. Expects nonce prepended to ciphertext.
+pub fun decrypt(key []byte, ciphertext []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// sign signs a message using Ed25519.
+pub fun sign(key PrivateKey, message []byte) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// verify verifies an Ed25519 signature.
+pub fun verify(key PublicKey, message []byte, sig []byte) !bool {
+    return false
+}
+
+// rand_bytes returns n cryptographically secure random bytes
+// from the operating system's CSPRNG.
+pub fun rand_bytes(n int) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// derive_key derives a key from a secret using HKDF with BLAKE3.
+// Returns a 32-byte derived key.
+pub fun derive_key(secret []byte, salt []byte, info []byte) []byte {
+    return alloc([]byte, 0)
+}

--- a/stdlib/encoding/json/json.run
+++ b/stdlib/encoding/json/json.run
@@ -88,6 +88,41 @@ pub fun (v Value) as_object() map[string]Value? {
     return null
 }
 
+// is_null reports whether the Value is null.
+pub fun (v @Value) is_null() bool {
+    return false
+}
+
+// is_bool reports whether the Value is a boolean.
+pub fun (v @Value) is_bool() bool {
+    return false
+}
+
+// is_int reports whether the Value is an integer.
+pub fun (v @Value) is_int() bool {
+    return false
+}
+
+// is_float reports whether the Value is a float.
+pub fun (v @Value) is_float() bool {
+    return false
+}
+
+// is_string reports whether the Value is a string.
+pub fun (v @Value) is_string() bool {
+    return false
+}
+
+// is_array reports whether the Value is an array.
+pub fun (v @Value) is_array() bool {
+    return false
+}
+
+// is_object reports whether the Value is an object.
+pub fun (v @Value) is_object() bool {
+    return false
+}
+
 // Encoder writes JSON values to an output stream.
 pub Encoder struct {
     writer io.Writer

--- a/stdlib/encoding/toml/toml.run
+++ b/stdlib/encoding/toml/toml.run
@@ -1,0 +1,97 @@
+package toml
+
+use "io"
+
+// TomlError represents errors during TOML encoding/decoding.
+pub type TomlError = .syntax_error
+    | .type_mismatch
+    | .duplicate_key
+    | .invalid_datetime
+    | .mixed_array
+
+// Value represents a TOML value.
+pub type Value = .string(string)
+    | .int(int)
+    | .float(f64)
+    | .bool(bool)
+    | .datetime(string)
+    | .array([]Value)
+    | .table(map[string]Value)
+
+// parse parses TOML data into a dynamic Value tree.
+pub fun parse(data string) !Value {
+    return .table(alloc(map[string]Value, 0))
+}
+
+// parse_file reads and parses a TOML file.
+pub fun parse_file(path string) !Value {
+    return .table(alloc(map[string]Value, 0))
+}
+
+// marshal encodes a value as a TOML string.
+pub fun marshal(value any) !string {
+    return ""
+}
+
+// unmarshal decodes TOML data into the value pointed to by target.
+pub fun unmarshal(data string, target &any) !void {
+}
+
+// get retrieves a nested value by key from a Value.
+pub fun (v @Value) get(key string) Value? {
+    return null
+}
+
+// get_string returns the string value for the given key, or null.
+pub fun (v @Value) get_string(key string) string? {
+    return null
+}
+
+// get_int returns the integer value for the given key, or null.
+pub fun (v @Value) get_int(key string) int? {
+    return null
+}
+
+// get_bool returns the boolean value for the given key, or null.
+pub fun (v @Value) get_bool(key string) bool? {
+    return null
+}
+
+// get_table returns the table value for the given key, or null.
+pub fun (v @Value) get_table(key string) Value? {
+    return null
+}
+
+// get_array returns the array value for the given key as a slice, or null.
+pub fun (v @Value) get_array(key string) []Value? {
+    return null
+}
+
+// Encoder writes TOML to an output stream.
+pub Encoder struct {
+    writer io.Writer
+}
+
+// new_encoder returns a new Encoder that writes to w.
+pub fun new_encoder(w io.Writer) Encoder {
+    return Encoder{ writer: w }
+}
+
+// encode writes the TOML encoding of v to the stream.
+pub fun (enc &Encoder) encode(value any) !void {
+}
+
+// Decoder reads and decodes TOML from an input stream.
+pub Decoder struct {
+    reader io.Reader
+}
+
+// new_decoder returns a new Decoder that reads from r.
+pub fun new_decoder(r io.Reader) Decoder {
+    return Decoder{ reader: r }
+}
+
+// decode reads TOML from the stream and stores it in the value
+// pointed to by target.
+pub fun (dec &Decoder) decode(target &any) !void {
+}

--- a/stdlib/encoding/xml/xml.run
+++ b/stdlib/encoding/xml/xml.run
@@ -1,0 +1,105 @@
+package xml
+
+use "io"
+
+// XmlError represents errors during XML encoding/decoding.
+pub type XmlError = .syntax_error
+    | .unexpected_eof
+    | .invalid_character
+    | .unclosed_tag
+    | .mismatched_tag
+
+// Name represents an XML name with local and namespace parts.
+pub Name struct {
+    local string
+    space string
+}
+
+// Attr represents an XML attribute.
+pub Attr struct {
+    name  Name
+    value string
+}
+
+// StartElement represents an XML start element with its attributes.
+pub StartElement struct {
+    name Name
+    attr []Attr
+}
+
+// EndElement represents an XML end element.
+pub EndElement struct {
+    name Name
+}
+
+// ProcInst represents an XML processing instruction.
+pub ProcInst struct {
+    target string
+    inst   string
+}
+
+// Token represents an XML token returned by the Decoder.
+pub type Token = .start_element(StartElement)
+    | .end_element(EndElement)
+    | .char_data(string)
+    | .comment(string)
+    | .proc_inst(ProcInst)
+    | .directive(string)
+
+// marshal encodes a value as XML bytes.
+pub fun marshal(v any) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// marshal_indent encodes a value as indented XML bytes.
+pub fun marshal_indent(v any, prefix string, indent string) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// unmarshal decodes XML bytes into the value pointed to by target.
+pub fun unmarshal(data []byte, target &any) !void {
+}
+
+// Encoder writes XML to an output stream.
+pub Encoder struct {
+    writer io.Writer
+}
+
+// new_encoder returns a new Encoder that writes to w.
+pub fun new_encoder(w io.Writer) Encoder {
+    return Encoder{ writer: w }
+}
+
+// encode writes the XML encoding of v to the stream.
+pub fun (enc &Encoder) encode(v any) !void {
+}
+
+// flush flushes any buffered XML to the underlying writer.
+pub fun (enc &Encoder) flush() !void {
+}
+
+// Decoder reads XML tokens from an input stream.
+pub Decoder struct {
+    reader io.Reader
+}
+
+// new_decoder returns a new Decoder that reads from r.
+pub fun new_decoder(r io.Reader) Decoder {
+    return Decoder{ reader: r }
+}
+
+// token reads the next XML token from the stream.
+// Returns null at end of input.
+pub fun (dec &Decoder) token() !Token? {
+    return null
+}
+
+// decode reads an XML element from the stream and stores it
+// in the value pointed to by target.
+pub fun (dec &Decoder) decode(target &any) !void {
+}
+
+// skip reads tokens until it has consumed the end element
+// matching the most recently consumed start element.
+pub fun (dec &Decoder) skip() !void {
+}

--- a/stdlib/encoding/yaml/yaml.run
+++ b/stdlib/encoding/yaml/yaml.run
@@ -1,0 +1,118 @@
+package yaml
+
+use "io"
+
+// YamlError represents errors during YAML encoding/decoding.
+pub type YamlError = .syntax_error
+    | .duplicate_key
+    | .invalid_anchor
+    | .circular_reference
+    | .type_mismatch
+    | .unsupported_tag
+
+// Value represents a YAML value.
+pub type Value = .null
+    | .bool(bool)
+    | .int(int)
+    | .float(f64)
+    | .string(string)
+    | .sequence([]Value)
+    | .mapping(map[string]Value)
+
+// marshal encodes a value as YAML bytes.
+pub fun marshal(value any) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// unmarshal decodes YAML bytes into the value pointed to by target.
+pub fun unmarshal(data []byte, target &any) !void {
+}
+
+// marshal_string encodes a value as a YAML string.
+pub fun marshal_string(value any) !string {
+    return ""
+}
+
+// parse parses YAML bytes into a dynamic Value tree.
+pub fun parse(data []byte) !Value {
+    return .null
+}
+
+// parse_string parses a YAML string into a dynamic Value tree.
+pub fun parse_string(s string) !Value {
+    return .null
+}
+
+// get retrieves a nested value by key from a Value.
+pub fun (v @Value) get(key string) Value? {
+    return null
+}
+
+// index retrieves an element by index from a sequence Value.
+pub fun (v @Value) index(i int) Value? {
+    return null
+}
+
+// as_string returns the string if the Value is a string, or null.
+pub fun (v @Value) as_string() string? {
+    return null
+}
+
+// as_int returns the int if the Value is an int, or null.
+pub fun (v @Value) as_int() int? {
+    return null
+}
+
+// as_float returns the float if the Value is a float, or null.
+pub fun (v @Value) as_float() f64? {
+    return null
+}
+
+// as_bool returns the bool if the Value is a bool, or null.
+pub fun (v @Value) as_bool() bool? {
+    return null
+}
+
+// as_sequence returns the sequence if the Value is a sequence, or null.
+pub fun (v @Value) as_sequence() []Value? {
+    return null
+}
+
+// as_mapping returns the mapping if the Value is a mapping, or null.
+pub fun (v @Value) as_mapping() map[string]Value? {
+    return null
+}
+
+// Encoder writes YAML to an output stream.
+pub Encoder struct {
+    writer io.Writer
+}
+
+// new_encoder returns a new Encoder that writes to w.
+pub fun new_encoder(w io.Writer) Encoder {
+    return Encoder{ writer: w }
+}
+
+// encode writes the YAML encoding of v to the stream.
+pub fun (enc &Encoder) encode(value any) !void {
+}
+
+// close flushes any remaining data and finalizes the YAML stream.
+pub fun (enc &Encoder) close() !void {
+}
+
+// Decoder reads and decodes YAML from an input stream.
+// Supports multi-document YAML files.
+pub Decoder struct {
+    reader io.Reader
+}
+
+// new_decoder returns a new Decoder that reads from r.
+pub fun new_decoder(r io.Reader) Decoder {
+    return Decoder{ reader: r }
+}
+
+// decode reads the next YAML document from the stream and stores it
+// in the value pointed to by target.
+pub fun (dec &Decoder) decode(target &any) !void {
+}

--- a/stdlib/errors/errors.run
+++ b/stdlib/errors/errors.run
@@ -1,0 +1,88 @@
+package errors
+
+// Error is the interface for all error values.
+pub type Error interface {
+    // message returns the error message.
+    message() string
+}
+
+// Wrapper is the interface for errors that wrap other errors.
+pub type Wrapper interface {
+    // unwrap returns the wrapped error, or null if none.
+    unwrap() Error?
+}
+
+// SimpleError is a basic error with a message string.
+pub SimpleError struct {
+    implements {
+        Error
+    }
+
+    msg string
+}
+
+// message returns the error message.
+pub fun (e @SimpleError) message() string {
+    return e.msg
+}
+
+// WrappedError is an error that wraps another error with additional context.
+pub WrappedError struct {
+    implements {
+        Error
+        Wrapper
+    }
+
+    msg   string
+    cause Error
+}
+
+// message returns the error message with context.
+pub fun (e @WrappedError) message() string {
+    return ""
+}
+
+// unwrap returns the wrapped inner error.
+pub fun (e @WrappedError) unwrap() Error? {
+    return null
+}
+
+// new creates a simple error with the given message.
+pub fun new(msg string) Error {
+    return SimpleError{ msg: msg }
+}
+
+// wrap wraps an error with additional context message.
+// The resulting error chain can be inspected with unwrap.
+pub fun wrap(err Error, msg string) Error {
+    return WrappedError{ msg: msg, cause: err }
+}
+
+// wrap_f wraps an error with a formatted context message.
+pub fun wrap_f(err Error, format string, args ...any) Error {
+    return WrappedError{ msg: "", cause: err }
+}
+
+// unwrap returns the error wrapped by err, or null if err does
+// not implement the Wrapper interface.
+pub fun unwrap(err Error) Error? {
+    return null
+}
+
+// is reports whether any error in err's chain matches target.
+// An error is considered a match if it is equal to the target.
+pub fun is(err Error, target Error) bool {
+    return false
+}
+
+// as attempts to find the first error in err's chain that matches
+// the target type and assigns it to target.
+pub fun as(err Error, target &any) bool {
+    return false
+}
+
+// join combines multiple errors into a single error.
+// Returns null if all errors are null.
+pub fun join(errs []Error) Error? {
+    return null
+}

--- a/stdlib/hash/crc32/crc32.run
+++ b/stdlib/hash/crc32/crc32.run
@@ -1,0 +1,51 @@
+package crc32
+
+use "hash"
+
+// Predefined CRC-32 polynomial constants.
+pub let ieee = 0xedb88320
+pub let castagnoli = 0x82f63b78
+pub let koopman = 0xeb31d82e
+
+// size is the size of a CRC-32 checksum in bytes.
+pub let size = 4
+
+// Table is a 256-word table representing the polynomial for efficient processing.
+pub Table struct {
+    entries [256]int
+}
+
+// ieee_table is the Table for the IEEE polynomial (most common).
+pub var ieee_table = make_table(0xedb88320)
+
+// castagnoli_table is the Table for the Castagnoli polynomial.
+pub var castagnoli_table = make_table(0x82f63b78)
+
+// koopman_table is the Table for the Koopman polynomial.
+pub var koopman_table = make_table(0xeb31d82e)
+
+// make_table returns a Table constructed from the specified polynomial.
+pub fun make_table(poly int) Table {
+    return Table{ entries: alloc([256]int, 0) }
+}
+
+// new creates a new hash.Hash32 computing the CRC-32 checksum
+// using the given polynomial table.
+pub fun new(tab @Table) hash.Hash32 {
+    return null
+}
+
+// checksum returns the CRC-32 checksum of data using the given table.
+pub fun checksum(data []byte, tab @Table) int {
+    return 0
+}
+
+// checksum_ieee returns the CRC-32 checksum of data using the IEEE polynomial.
+pub fun checksum_ieee(data []byte) int {
+    return 0
+}
+
+// update adds data to the running CRC-32 checksum.
+pub fun update(crc int, tab @Table, data []byte) int {
+    return 0
+}

--- a/stdlib/hash/fnv/fnv.run
+++ b/stdlib/hash/fnv/fnv.run
@@ -1,0 +1,33 @@
+package fnv
+
+use "hash"
+
+// new32 returns a new hash.Hash32 computing the FNV-1 32-bit hash.
+pub fun new32() hash.Hash32 {
+    return null
+}
+
+// new32a returns a new hash.Hash32 computing the FNV-1a 32-bit hash.
+pub fun new32a() hash.Hash32 {
+    return null
+}
+
+// new64 returns a new hash.Hash64 computing the FNV-1 64-bit hash.
+pub fun new64() hash.Hash64 {
+    return null
+}
+
+// new64a returns a new hash.Hash64 computing the FNV-1a 64-bit hash.
+pub fun new64a() hash.Hash64 {
+    return null
+}
+
+// new128 returns a new hash computing the FNV-1 128-bit hash.
+pub fun new128() hash.Hash64 {
+    return null
+}
+
+// new128a returns a new hash computing the FNV-1a 128-bit hash.
+pub fun new128a() hash.Hash64 {
+    return null
+}

--- a/stdlib/html/html.run
+++ b/stdlib/html/html.run
@@ -1,0 +1,19 @@
+package html
+
+// escape_string replaces special characters in s with HTML entities.
+// It escapes the five characters: < > & " '
+//   < becomes &lt;
+//   > becomes &gt;
+//   & becomes &amp;
+//   " becomes &quot;
+//   ' becomes &#39;
+pub fun escape_string(s string) string {
+    return ""
+}
+
+// unescape_string unescapes HTML entities in s.
+// It converts &lt; &gt; &amp; &quot; &#39; and numeric character
+// references back to their original characters.
+pub fun unescape_string(s string) string {
+    return ""
+}

--- a/stdlib/io/fs/fs.run
+++ b/stdlib/io/fs/fs.run
@@ -1,0 +1,112 @@
+package fs
+
+use "io"
+
+// FsError represents errors from filesystem operations.
+pub type FsError = .not_found
+    | .permission_denied
+    | .not_directory
+    | .invalid_path
+
+// FS provides access to a hierarchical file system.
+pub type FS interface {
+    // open opens the named file.
+    open(name string) !File
+}
+
+// File provides access to a single file.
+pub type File interface {
+    // stat returns the FileInfo for the file.
+    stat() !FileInfo
+
+    // read reads up to len(buf) bytes into buf.
+    read(buf []byte) !int
+
+    // close closes the file.
+    close() !void
+}
+
+// ReadDirFS is an FS that can enumerate directory entries.
+pub type ReadDirFS interface {
+    // open opens the named file.
+    open(name string) !File
+
+    // read_dir reads the named directory and returns a list of directory entries.
+    read_dir(name string) ![]DirEntry
+}
+
+// StatFS is an FS that can stat files without opening them.
+pub type StatFS interface {
+    // open opens the named file.
+    open(name string) !File
+
+    // stat returns a FileInfo describing the named file.
+    stat(name string) !FileInfo
+}
+
+// FileInfo describes a file and is returned by stat.
+pub type FileInfo interface {
+    // name returns the base name of the file.
+    name() string
+
+    // size returns the length in bytes for regular files.
+    size() int
+
+    // mode returns the file mode bits.
+    mode() FileMode
+
+    // mod_time returns the modification time as a Unix timestamp.
+    mod_time() int
+
+    // is_dir reports whether the file is a directory.
+    is_dir() bool
+}
+
+// DirEntry is an entry read from a directory.
+pub type DirEntry interface {
+    // name returns the name of the file described by the entry.
+    name() string
+
+    // is_dir reports whether the entry describes a directory.
+    is_dir() bool
+
+    // type_mode returns the type bits for the entry.
+    type_mode() FileMode
+
+    // info returns the FileInfo for the file described by the entry.
+    info() !FileInfo
+}
+
+// FileMode represents a file's mode and permission bits.
+pub type FileMode = .regular
+    | .directory
+    | .symlink
+    | .socket
+    | .pipe
+    | .device
+
+// walk_dir walks the file tree rooted at root, calling fn for each file
+// or directory in the tree, including root.
+pub fun walk_dir(fsys FS, root string, fn fun(path string, d DirEntry, err any) any) {
+}
+
+// sub returns an FS corresponding to the subtree rooted at dir.
+pub fun sub(fsys FS, dir string) !FS {
+    return null
+}
+
+// glob returns the names of all files matching the pattern.
+pub fun glob(fsys FS, pattern string) ![]string {
+    return alloc([]string, 0)
+}
+
+// read_file reads the named file from the file system fs and returns its contents.
+pub fun read_file(fsys FS, name string) ![]byte {
+    return alloc([]byte, 0)
+}
+
+// valid_path reports whether the given path name is valid for use
+// with an FS implementation.
+pub fun valid_path(name string) bool {
+    return false
+}

--- a/stdlib/iter/iter.run
+++ b/stdlib/iter/iter.run
@@ -1,0 +1,98 @@
+package iter
+
+// Iterator is the interface for lazy iteration over sequences.
+pub type Iterator interface {
+    // next returns the next element, or null when exhausted.
+    next() any?
+}
+
+// from_slice creates an iterator over the elements of a slice.
+pub fun from_slice(s []any) Iterator {
+    return null
+}
+
+// range creates an iterator over integers in [start, end).
+pub fun range(start int, end int) Iterator {
+    return null
+}
+
+// map returns an iterator that applies f to each element.
+pub fun map(it Iterator, f fun(any) any) Iterator {
+    return null
+}
+
+// filter returns an iterator that yields only elements where f returns true.
+pub fun filter(it Iterator, f fun(any) bool) Iterator {
+    return null
+}
+
+// reduce reduces the iterator to a single value by applying f
+// to an accumulator and each element.
+pub fun reduce(it Iterator, init any, f fun(acc any, item any) any) any {
+    return null
+}
+
+// take returns an iterator that yields at most n elements.
+pub fun take(it Iterator, n int) Iterator {
+    return null
+}
+
+// skip returns an iterator that skips the first n elements.
+pub fun skip(it Iterator, n int) Iterator {
+    return null
+}
+
+// zip combines two iterators element-wise into an iterator of pairs.
+pub fun zip(a Iterator, b Iterator) Iterator {
+    return null
+}
+
+// chain chains two iterators sequentially.
+pub fun chain(a Iterator, b Iterator) Iterator {
+    return null
+}
+
+// enumerate wraps an iterator to yield (index, item) pairs.
+pub fun enumerate(it Iterator) Iterator {
+    return null
+}
+
+// count consumes the iterator and returns the number of elements.
+pub fun count(it Iterator) int {
+    return 0
+}
+
+// any_match reports whether f returns true for any element.
+pub fun any_match(it Iterator, f fun(any) bool) bool {
+    return false
+}
+
+// all_match reports whether f returns true for all elements.
+pub fun all_match(it Iterator, f fun(any) bool) bool {
+    return false
+}
+
+// collect consumes the iterator and collects all elements into a slice.
+pub fun collect(it Iterator) []any {
+    return alloc([]any, 0)
+}
+
+// for_each applies f to each element in the iterator.
+pub fun for_each(it Iterator, f fun(any)) {
+}
+
+// flat_map applies f to each element and flattens the resulting iterators.
+pub fun flat_map(it Iterator, f fun(any) Iterator) Iterator {
+    return null
+}
+
+// take_while returns an iterator that yields elements while f returns true.
+pub fun take_while(it Iterator, f fun(any) bool) Iterator {
+    return null
+}
+
+// skip_while returns an iterator that skips elements while f returns true,
+// then yields the rest.
+pub fun skip_while(it Iterator, f fun(any) bool) Iterator {
+    return null
+}

--- a/stdlib/maps/maps.run
+++ b/stdlib/maps/maps.run
@@ -1,0 +1,44 @@
+package maps
+
+// keys returns the keys of the map as a slice.
+// The order of keys is not guaranteed.
+pub fun keys(m map[any]any) []any {
+    return alloc([]any, 0)
+}
+
+// values returns the values of the map as a slice.
+// The order of values is not guaranteed.
+pub fun values(m map[any]any) []any {
+    return alloc([]any, 0)
+}
+
+// clone returns a shallow copy of the map.
+pub fun clone(m map[any]any) map[any]any {
+    return alloc(map[any]any, 0)
+}
+
+// equal reports whether two maps contain the same key/value pairs.
+pub fun equal(a map[any]any, b map[any]any) bool {
+    return false
+}
+
+// equal_func reports whether two maps contain the same keys and
+// the values satisfy the provided equality function.
+pub fun equal_func(a map[any]any, b map[any]any, eq fun(v1 any, v2 any) bool) bool {
+    return false
+}
+
+// delete_func deletes all entries from m for which f returns true.
+pub fun delete_func(m map[any]any, f fun(key any, value any) bool) {
+}
+
+// copy copies all key/value pairs from src to dst.
+// When a key in src is already present in dst, the value in dst
+// is overwritten with the value from src.
+pub fun copy(dst map[any]any, src map[any]any) {
+}
+
+// has reports whether the map contains the given key.
+pub fun has(m map[any]any, key any) bool {
+    return false
+}

--- a/stdlib/math/bits/bits.run
+++ b/stdlib/math/bits/bits.run
@@ -1,0 +1,82 @@
+package bits
+
+// leading_zeros returns the number of leading zero bits in x.
+// Returns 64 for x == 0.
+pub fun leading_zeros(x int) int {
+    return 0
+}
+
+// trailing_zeros returns the number of trailing zero bits in x.
+// Returns 64 for x == 0.
+pub fun trailing_zeros(x int) int {
+    return 0
+}
+
+// ones_count returns the number of one bits (population count) in x.
+pub fun ones_count(x int) int {
+    return 0
+}
+
+// rotate_left returns the value of x rotated left by k bits.
+// To rotate right, use a negative k.
+pub fun rotate_left(x int, k int) int {
+    return 0
+}
+
+// rotate_right returns the value of x rotated right by k bits.
+// To rotate left, use a negative k.
+pub fun rotate_right(x int, k int) int {
+    return 0
+}
+
+// reverse returns the value of x with its bits in reversed order.
+pub fun reverse(x int) int {
+    return 0
+}
+
+// reverse_bytes returns the value of x with its bytes in reversed order.
+pub fun reverse_bytes(x int) int {
+    return 0
+}
+
+// len returns the minimum number of bits required to represent x.
+// Returns 0 for x == 0.
+pub fun len(x int) int {
+    return 0
+}
+
+// add returns the sum with carry of x, y, and carry_in.
+// carry_in must be 0 or 1; otherwise the behavior is undefined.
+// Returns (sum, carry_out) where carry_out is 0 or 1.
+pub fun add(x int, y int, carry_in int) int {
+    return 0
+}
+
+// sub returns the difference of x, y, and borrow_in.
+// borrow_in must be 0 or 1; otherwise the behavior is undefined.
+// Returns (diff, borrow_out) where borrow_out is 0 or 1.
+pub fun sub(x int, y int, borrow_in int) int {
+    return 0
+}
+
+// mul returns the full-width product of x and y: (hi, lo) = x * y
+// with the product bits' upper half returned in hi and the lower
+// half returned in lo.
+pub fun mul(x int, y int) int {
+    return 0
+}
+
+// leading_zeros32 returns the number of leading zero bits in a 32-bit value.
+pub fun leading_zeros32(x int) int {
+    return 0
+}
+
+// trailing_zeros32 returns the number of trailing zero bits in a 32-bit value.
+pub fun trailing_zeros32(x int) int {
+    return 0
+}
+
+// ones_count32 returns the number of one bits in a 32-bit value.
+pub fun ones_count32(x int) int {
+    return 0
+}

--- a/stdlib/path/path.run
+++ b/stdlib/path/path.run
@@ -1,0 +1,69 @@
+package path
+
+// join joins any number of path elements into a single path,
+// separating them with forward slashes. Empty elements are ignored.
+// This is OS-independent; for OS-specific path handling use os.join_path.
+pub fun join(parts ...string) string {
+    return ""
+}
+
+// base returns the last element of path.
+// Trailing slashes are removed before extracting the last element.
+// If the path is empty, base returns ".".
+// If the path consists entirely of slashes, base returns "/".
+pub fun base(p string) string {
+    return ""
+}
+
+// dir returns all but the last element of path, typically the path's directory.
+// Trailing slashes are removed before processing.
+// If the path is empty, dir returns ".".
+pub fun dir(p string) string {
+    return ""
+}
+
+// ext returns the file name extension used by path.
+// The extension is the suffix beginning at the final dot
+// in the last element of path; it is empty if there is no dot.
+pub fun ext(p string) string {
+    return ""
+}
+
+// clean returns the shortest path name equivalent to path
+// by purely lexical processing. It applies the following rules
+// iteratively until no further processing can be done:
+//   1. Replace multiple slashes with a single slash.
+//   2. Eliminate each . path name element.
+//   3. Eliminate each inner .. path name element along with the
+//      non-.. element that precedes it.
+//   4. Eliminate .. elements that begin a rooted path.
+pub fun clean(p string) string {
+    return ""
+}
+
+// is_abs reports whether the path is absolute.
+pub fun is_abs(p string) bool {
+    return false
+}
+
+// split splits path immediately following the final slash,
+// separating it into a directory and file name component.
+// If there is no slash in path, split returns ("", path).
+pub fun split(p string) string {
+    return ""
+}
+
+// match reports whether name matches the shell file name pattern.
+// The pattern syntax is:
+//   *       matches any sequence of non-/ characters
+//   ?       matches any single non-/ character
+//   [...]   matches any character in the bracket set
+pub fun match(pattern string, name string) !bool {
+    return false
+}
+
+// rel returns a relative path that is lexically equivalent to target
+// when joined to base with an intervening separator.
+pub fun rel(base_path string, target string) !string {
+    return ""
+}

--- a/stdlib/slices/slices.run
+++ b/stdlib/slices/slices.run
@@ -1,0 +1,91 @@
+package slices
+
+// contains reports whether v is present in s.
+pub fun contains(s []any, v any) bool {
+    return false
+}
+
+// index returns the index of the first occurrence of v in s,
+// or null if v is not present.
+pub fun index(s []any, v any) int? {
+    return null
+}
+
+// last_index returns the index of the last occurrence of v in s,
+// or null if v is not present.
+pub fun last_index(s []any, v any) int? {
+    return null
+}
+
+// compact removes consecutive duplicate elements from s.
+pub fun compact(s []any) []any {
+    return alloc([]any, 0)
+}
+
+// sort_func sorts s in-place using the provided comparison function.
+// cmp(a, b) should return a negative number when a < b, zero when a == b,
+// and a positive number when a > b.
+pub fun sort_func(s []any, cmp fun(a any, b any) int) {
+}
+
+// is_sorted_func reports whether s is sorted according to the comparison function.
+pub fun is_sorted_func(s []any, cmp fun(a any, b any) int) bool {
+    return false
+}
+
+// reverse reverses the elements of s in place.
+pub fun reverse(s []any) {
+}
+
+// grow increases the capacity of s by at least n additional elements.
+pub fun grow(s []any, n int) []any {
+    return alloc([]any, 0)
+}
+
+// insert inserts the value v at index i, shifting subsequent elements right.
+pub fun insert(s []any, i int, v any) []any {
+    return alloc([]any, 0)
+}
+
+// delete removes the element at index i from s.
+pub fun delete(s []any, i int) []any {
+    return alloc([]any, 0)
+}
+
+// clone returns a shallow copy of s.
+pub fun clone(s []any) []any {
+    return alloc([]any, 0)
+}
+
+// equal reports whether two slices are equal: the same length and all
+// elements equal.
+pub fun equal(a []any, b []any) bool {
+    return false
+}
+
+// min_func returns the minimum element of s according to the comparison function.
+pub fun min_func(s []any, cmp fun(a any, b any) int) any {
+    return null
+}
+
+// max_func returns the maximum element of s according to the comparison function.
+pub fun max_func(s []any, cmp fun(a any, b any) int) any {
+    return null
+}
+
+// binary_search_func searches for target in a sorted slice using the
+// comparison function. Returns the index if found, or null.
+pub fun binary_search_func(s []any, target any, cmp fun(a any, b any) int) int? {
+    return null
+}
+
+// chunk splits s into sub-slices of the given size.
+// The last chunk may have fewer elements.
+pub fun chunk(s []any, size int) [][]any {
+    return alloc([][]any, 0)
+}
+
+// concat returns a new slice concatenating the provided slices.
+pub fun concat(slices_list [][]any) []any {
+    return alloc([]any, 0)
+}

--- a/stdlib/text/template/template.run
+++ b/stdlib/text/template/template.run
@@ -1,0 +1,57 @@
+package template
+
+use "io"
+
+// TemplateError represents errors during template parsing or execution.
+pub type TemplateError = .parse_error
+    | .exec_error
+    | .undefined_variable
+    | .undefined_function
+    | .wrong_arg_count
+
+// Template is a parsed template that can be executed with data.
+// Template syntax:
+//   {{ .field }}              — field access
+//   {{ if .cond }}...{{ end }}  — conditional
+//   {{ range .items }}...{{ end }} — iteration
+//   {{ .value | func }}       — pipeline
+//   {{ template "name" . }}   — include sub-template
+pub Template struct {
+    name string
+}
+
+// new creates a new, empty template with the given name.
+pub fun new(name string) Template {
+    return Template{ name: name }
+}
+
+// parse parses the template text and returns the resulting Template.
+pub fun parse(text string) !Template {
+    return Template{ name: "" }
+}
+
+// parse_files reads and parses the named files as templates.
+pub fun parse_files(filenames ...string) !Template {
+    return Template{ name: "" }
+}
+
+// must is a helper that panics if err is non-null, otherwise returns t.
+// It is intended for use in variable initializations.
+pub fun must(t Template) Template {
+    return t
+}
+
+// execute applies the parsed template to the data and writes the output to wr.
+pub fun (t @Template) execute(wr io.Writer, data any) !void {
+}
+
+// execute_string applies the parsed template to the data and returns
+// the result as a string.
+pub fun (t @Template) execute_string(data any) !string {
+    return ""
+}
+
+// name returns the name of the template.
+pub fun (t @Template) name() string {
+    return t.name
+}


### PR DESCRIPTION
## Summary

Implements the stdlib redesign from [RFC #219](https://github.com/marsolab/runlang/issues/219):

- **16 new packages** with full API stubs: `errors`, `iter`, `slices`, `maps`, `cmp`, `math/bits`, `path`, `encoding/toml`, `encoding/yaml`, `encoding/xml`, `compress/zstd`, `io/fs`, `html`, `text/template`, `hash/crc32`, `hash/fnv`
- **`crypto`** — added recommended defaults (`hash`, `encrypt`, `decrypt`, `sign`, `verify`, `rand_bytes`, `derive_key`)
- **`encoding/json`** — added `is_null`, `is_bool`, `is_int`, `is_float`, `is_string`, `is_array`, `is_object` type inspection methods
- **`docs/stdlib/packages.md`** — updated with all new package entries, milestone mappings (M10–M13), and total count (50 → 67 packages)

All new files follow existing stub conventions and tokenize/parse cleanly. Build and tests pass.

Refs #219, #231, #237, #238, #239, #240, #241, #242, #252, #253, #254, #255, #256, #257, #258, #259, #260

## Test plan

- [x] `zig build` compiles successfully
- [x] `zig build test` passes all existing tests
- [x] All new `.run` files tokenize correctly (verified via `run tokens`)
- [ ] Manual review of API signatures against RFC #219 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)