### PR TITLE
Fix errors package syntax to match parser (#231)

### DIFF
--- a/stdlib/errors/errors.run
+++ b/stdlib/errors/errors.run
@@ -1,22 +1,22 @@
 package errors
 
 // Error is the interface for all error values.
-pub type Error interface {
+pub interface Error {
     // message returns the error message.
     message() string
 }
 
 // Wrapper is the interface for errors that wrap other errors.
-pub type Wrapper interface {
+pub interface Wrapper {
     // unwrap returns the wrapped error, or null if none.
     unwrap() Error?
 }
 
 // SimpleError is a basic error with a message string.
 pub SimpleError struct {
-    implements {
-        Error
-    }
+    implements (
+        Error,
+    )
 
     msg string
 }
@@ -28,10 +28,10 @@ pub fun (e @SimpleError) message() string {
 
 // WrappedError is an error that wraps another error with additional context.
 pub WrappedError struct {
-    implements {
-        Error
-        Wrapper
-    }
+    implements (
+        Error,
+        Wrapper,
+    )
 
     msg   string
     cause Error

--- a/stdlib/errors/errors_test.run
+++ b/stdlib/errors/errors_test.run
@@ -1,0 +1,5 @@
+package errors
+
+use "testing"
+
+// Tests for errors package will go here.


### PR DESCRIPTION
## Summary

- Fix interface declarations in `stdlib/errors/errors.run` to use `pub interface Name` instead of `pub type Name interface`, matching the parser at `src/parser.zig:111`
- Fix `implements` blocks to use parentheses instead of braces, matching the parser at `src/parser.zig:315`
- Add `stdlib/errors/errors_test.run` skeleton for future tests

Preparatory work for #231. Full implementation is blocked by #230 (error chain design decision).

## Test plan

- [x] `zig build test` passes (only `.run` files touched, no compiler changes)
- [ ] Verify syntax matches parser expectations for `interface` and `implements`


🤖 Generated with [Claude Code](https://claude.com/claude-code)