### PR TITLE
Fix interface declaration syntax to use `type Name interface`

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -110,7 +110,7 @@ pub const Node = struct {
         /// lhs = extra_data start, rhs = field count
         /// extra_data layout: [implements_count, iface1, ..., ifaceN, field1, ..., fieldM]
         struct_decl,
-        /// `interface Name { method_sigs }`
+        /// `type Name interface { method_sigs }`
         /// lhs = extra_data start for method sigs, rhs = count
         interface_decl,
         /// Bare method signature in an interface: `name(params) ret_type`

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -108,7 +108,6 @@ pub const Parser = struct {
         return switch (self.peekTag()) {
             .kw_pub => self.parsePubDecl(),
             .kw_fun => self.parseFnDecl(),
-            .kw_interface => self.parseInterfaceDecl(),
             .kw_type => self.parseTypeAlias(),
             .kw_package => self.parsePackageDecl(),
             .kw_import => self.parseImportDecl(),
@@ -133,7 +132,6 @@ pub const Parser = struct {
 
         const inner = switch (self.peekTag()) {
             .kw_fun => try self.parseFnDecl(),
-            .kw_interface => try self.parseInterfaceDecl(),
             .kw_type => try self.parseTypeAlias(),
             .kw_package => blk: {
                 try self.addError(.expected_expression, self.currentLoc(), null);
@@ -397,15 +395,10 @@ pub const Parser = struct {
         });
     }
 
-    fn parseInterfaceDecl(self: *Parser) Error!NodeIndex {
-        const tok = self.pos;
+    /// Parse interface body after `type Name` has already been consumed.
+    /// `type_tok` points to the `kw_type` token (name is at type_tok + 1).
+    fn parseInterfaceBody(self: *Parser, type_tok: u32) Error!NodeIndex {
         self.expect(.kw_interface);
-
-        if (self.peekTag() != .identifier) {
-            try self.addError(.expected_identifier, self.currentLoc(), null);
-            return null_node;
-        }
-        self.advance();
 
         self.skipNewlines();
         self.expectToken(.l_brace);
@@ -432,7 +425,7 @@ pub const Parser = struct {
 
         return self.tree.addNode(.{
             .tag = .interface_decl,
-            .main_token = tok,
+            .main_token = type_tok,
             .data = .{ .lhs = start, .rhs = @as(NodeIndex, @intCast(methods.items.len)) },
         });
     }
@@ -474,6 +467,11 @@ pub const Parser = struct {
             return null_node;
         }
         self.advance(); // type name
+
+        // Interface declaration: type Name interface { ... }
+        if (self.peekTag() == .kw_interface) {
+            return self.parseInterfaceBody(tok);
+        }
 
         // Disambiguate: `type Name = .variants` (sum type) vs `type Name <type>` (type decl)
         if (self.peekTag() == .equal) {
@@ -2187,7 +2185,7 @@ test "parse struct with implements and colons" {
 }
 
 test "parse interface" {
-    const source = "pub interface Stringer {\n    string() string\n}";
+    const source = "pub type Stringer interface {\n    string() string\n}";
     var lexer = Lexer.init(source);
     var tokens = try lexer.tokenize(std.testing.allocator);
     defer tokens.deinit(std.testing.allocator);
@@ -2210,7 +2208,7 @@ test "parse interface" {
 }
 
 test "parse interface with multiple methods" {
-    const source = "interface ReadWriter {\n    read(buf: []byte) !int\n    write(buf: []byte) !int\n}";
+    const source = "type ReadWriter interface {\n    read(buf: []byte) !int\n    write(buf: []byte) !int\n}";
     var lexer = Lexer.init(source);
     var tokens = try lexer.tokenize(std.testing.allocator);
     defer tokens.deinit(std.testing.allocator);

--- a/src/resolve.zig
+++ b/src/resolve.zig
@@ -221,7 +221,7 @@ pub const Resolver = struct {
     }
 
     fn collectInterfaceDecl(self: *Resolver, node: NodeIndex, is_pub: bool) ResolveError!void {
-        // interface_decl: main_token = kw_interface, name is next token
+        // interface_decl: main_token = kw_type, name is next token
         const main_tok = self.nodeMainToken(node);
         const name_tok = main_tok + 1;
         const name = self.tokenSlice(name_tok);

--- a/src/typecheck.zig
+++ b/src/typecheck.zig
@@ -3776,7 +3776,7 @@ test "typecheck: struct field with struct type" {
 
 test "typecheck: struct satisfies interface" {
     const result = try testTypeCheck(
-        \\interface Stringer {
+        \\type Stringer interface {
         \\    to_string() string
         \\}
         \\Point struct {
@@ -3796,7 +3796,7 @@ test "typecheck: struct satisfies interface" {
 
 test "typecheck: struct missing method from interface" {
     const has_err = try testTypeCheckHasErrorContaining(
-        \\interface Stringer {
+        \\type Stringer interface {
         \\    to_string() string
         \\}
         \\Point struct {
@@ -3812,7 +3812,7 @@ test "typecheck: struct missing method from interface" {
 
 test "typecheck: method wrong parameter type" {
     const has_err = try testTypeCheckHasErrorContaining(
-        \\interface Adder {
+        \\type Adder interface {
         \\    add(x int) int
         \\}
         \\Calc struct {
@@ -3831,7 +3831,7 @@ test "typecheck: method wrong parameter type" {
 
 test "typecheck: method wrong return type" {
     const has_err = try testTypeCheckHasErrorContaining(
-        \\interface Stringer {
+        \\type Stringer interface {
         \\    to_string() string
         \\}
         \\Point struct {
@@ -3850,7 +3850,7 @@ test "typecheck: method wrong return type" {
 
 test "typecheck: method wrong parameter count" {
     const has_err = try testTypeCheckHasErrorContaining(
-        \\interface Adder {
+        \\type Adder interface {
         \\    add(x int) int
         \\}
         \\Calc struct {
@@ -3869,10 +3869,10 @@ test "typecheck: method wrong parameter count" {
 
 test "typecheck: struct satisfies multiple interfaces" {
     const result = try testTypeCheck(
-        \\interface Stringer {
+        \\type Stringer interface {
         \\    to_string() string
         \\}
-        \\interface Adder {
+        \\type Adder interface {
         \\    add(x int) int
         \\}
         \\Widget struct {
@@ -3895,10 +3895,10 @@ test "typecheck: struct satisfies multiple interfaces" {
 
 test "typecheck: one of multiple interfaces not satisfied" {
     const has_err = try testTypeCheckHasErrorContaining(
-        \\interface Stringer {
+        \\type Stringer interface {
         \\    to_string() string
         \\}
-        \\interface Adder {
+        \\type Adder interface {
         \\    add(x int) int
         \\}
         \\Widget struct {
@@ -3931,7 +3931,7 @@ test "typecheck: undefined interface in implements" {
 
 test "typecheck: interface type as function parameter" {
     const result = try testTypeCheck(
-        \\interface Stringer {
+        \\type Stringer interface {
         \\    to_string() string
         \\}
         \\fn print_it(s Stringer) {


### PR DESCRIPTION
## Summary

- Changes interface declaration syntax from `interface Name { ... }` to `type Name interface { ... }`, matching the `type Name <keyword>` pattern used by other type declarations
- Routes interface parsing through the existing `kw_type` → `parseTypeAlias` path instead of a separate `kw_interface` dispatch
- Updates AST/resolver comments and all parser + typecheck test cases to use the new syntax

## Test plan

- [x] `zig build test` — all unit tests pass