### PR TITLE
Add self-improvement mistake tracking to CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ main
 main.o
 /run
 /test
+.agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,24 @@ These differ from older Zig versions and are critical to get right:
 
 Lexer and parser are complete. No semantic analysis, type checking, or code generation yet.
 
+## Self-Improvement
+
+When you make a mistake or encounter an error during work, document it so future sessions can avoid the same pitfall.
+
+1. **Before starting work**, read all files in `.agents/memory/mistakes/` to learn from past mistakes
+2. **When a mistake happens** (build error you caused, wrong API usage, misunderstanding of codebase conventions, etc.), create a file:
+
+   ```
+   .agents/memory/mistakes/YYYY-MM-DD_short-name.md
+   ```
+
+   The file must contain:
+   - **What went wrong** — describe the mistake clearly
+   - **Why it happened** — root cause (wrong assumption, outdated knowledge, etc.)
+   - **How to avoid it** — the correct approach for next time
+
+3. Keep filenames descriptive (e.g., `2026-03-21_arraylist-init-api.md`, `2026-03-21_wrong-stdout-writer.md`)
+
 ## Project Management
 
 Before starting any work, always:


### PR DESCRIPTION
## Summary
- Adds a **Self-Improvement** section to `CLAUDE.md` instructing agents to log mistakes to `.agents/memory/mistakes/` with date-prefixed filenames
- Each mistake file captures what went wrong, why, and how to avoid it in the future
- Agents are instructed to read existing mistake files before starting work
- Adds `.agents/` to `.gitignore` to keep mistake logs local

## Test plan
- [ ] Verify the new section renders correctly in `CLAUDE.md`
- [ ] Confirm `.agents/` is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)