### PR TITLE
stdlib/os: finish os API (create_temp, getwd) and harden path/IO helpers (#234)

### DIFF
--- a/docs/stdlib/packages.md
+++ b/docs/stdlib/packages.md
@@ -110,7 +110,8 @@ read_link(path) !string       — read symlink target
 chmod(path, mode) !void       — change permissions
 chown(path, uid, gid) !void   — change ownership
 temp_dir() string             — OS temp directory
-temp_file(prefix) !File       — create temp file
+create_temp(prefix) !File     — create temp file
+temp_file(prefix) !File       — backward-compatible alias for create_temp
 
 // Path utilities (no separate path package)
 join_path(parts []string) string   — join path components
@@ -133,6 +134,7 @@ exit(code)                     — terminate process
 getpid() int                   — current process ID
 hostname() !string             — machine hostname
 cwd() !string                  — current working directory
+getwd() !string                — backward-compatible alias for cwd
 chdir(path) !void              — change working directory
 user_home_dir() !string        — user home directory
 

--- a/stdlib/os/os.run
+++ b/stdlib/os/os.run
@@ -160,18 +160,27 @@ pub fun mkdir(path string) !void {
 
 // mkdir_all creates a directory path, including any missing parents.
 pub fun mkdir_all(path string) !void {
-    if len(path) == 0 {
+    if len(path) == 0 or path == "." {
         return
     }
-    let parent = dir(path)
-    if len(parent) > 0 and parent != path {
-        mkdir_all(parent)
+    let cleaned = clean(path)
+    if cleaned == "." or cleaned == "/" {
+        return
     }
-    @syscall.mkdir(path, 493)
+    let parent = dir(cleaned)
+    if len(parent) > 0 and parent != cleaned {
+        try mkdir_all(parent)
+    }
+    try @syscall.mkdir(cleaned, 493)
 }
 
 // remove removes the named file or empty directory.
 pub fun remove(path string) !void {
+    let info = try lstat(path)
+    if info.is_dir {
+        try @syscall.rmdir(path)
+        return
+    }
     try @syscall.unlink(path)
 }
 
@@ -266,18 +275,28 @@ pub fun temp_dir() string {
     }
 }
 
-// temp_file creates a new temporary file with the given prefix in the
+// create_temp creates a new temporary file with the given prefix in the
 // default temp directory. The caller is responsible for closing and
 // removing the file.
+pub fun create_temp(prefix string) !File {
+    let template = join_path([temp_dir(), prefix + "XXXXXX"])
+    let fd = try @syscall.mkstemp(template)
+    return File{ fd: fd, path: template }
+}
+
+// temp_file is a backward-compatible alias for create_temp.
 pub fun temp_file(prefix string) !File {
-    let path = join_path([temp_dir(), prefix])
-    let fd = try @syscall.mkstemp(path)
-    return File{ fd: fd, path: path }
+    return try create_temp(prefix)
 }
 
 // cwd returns the current working directory.
 pub fun cwd() !string {
     return try @syscall.getcwd()
+}
+
+// getwd is a backward-compatible alias for cwd.
+pub fun getwd() !string {
+    return try cwd()
 }
 
 // chdir changes the current working directory.
@@ -290,6 +309,9 @@ pub fun read_file(path string) ![]byte {
     let f = try open(path)
     defer f.close()
     let info = try stat(path)
+    if info.size <= 0 {
+        return alloc([]byte, 0)
+    }
     var buf = alloc([]byte, info.size)
     var total = 0
     for total < info.size {
@@ -383,6 +405,9 @@ pub fun dir(path string) string {
 
 // ext returns the file name extension used by path.
 pub fun ext(path string) string {
+    if len(path) == 0 {
+        return ""
+    }
     var i = len(path) - 1
     for i >= 0 {
         if path[i] == 46 {


### PR DESCRIPTION
### Motivation
- Complete the remaining `os` stdlib surface expected by the issue by adding missing temp-file and working-directory helpers and make the implementation match the docs. 
- Harden common filesystem helpers to avoid unsafe assumptions around empty paths, zero-length files, and parent-directory creation semantics.

### Description
- Add `create_temp(prefix string) !File` which constructs a `XXXXXX` template and calls the syscall `mkstemp`, and make `temp_file` a backward-compatible alias that calls `create_temp`.
- Add `getwd() !string` as a backward-compatible alias to `cwd()` so both names are available.
- Tighten `mkdir_all(path string) !void` to treat `"."` and empty paths as no-ops, clean the path with `clean()`, and propagate errors when recursing; use `try @syscall.mkdir(cleaned, 493)`.
- Make `remove(path string) !void` inspect the path via `lstat` and call `rmdir` for directories and `unlink` for files rather than always unlinking.
- Fix `read_file(path string) ![]byte` to return an empty slice for zero-length files and avoid invalid allocations/reads when `info.size <= 0`.
- Fix `ext(path string) string` to return `""` for empty input and avoid out-of-bounds indexing.
- Update documentation `docs/stdlib/packages.md` to reflect the new `create_temp`/`temp_file` and `cwd`/`getwd` API aliases and keep docs in sync with implementation.

### Testing
- Ran repository checks: `git diff --check` (no problems) and the repository search `rg -n "pub fun (create_temp|getwd|temp_file|cwd|mkdir_all|remove|read_file|ext)" stdlib/os/os.run docs/stdlib/packages.md` to confirm symbols are present; these checks succeeded. 
- Performed the local commit `git add`/`git commit` to record the changes successfully. 
- Attempted the project test run with `zig build test` but it could not be executed in this environment because `zig` is not installed (automated tests could not be run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03e9b1dec832c8d915f7c0ed3889c)

Closes [234](https://github.com/marsolab/runlang/issues/234)