### PR TITLE
Add `syscall` keyword and replace `@syscall` syntax

### DIFF
--- a/docs/stdlib/design.md
+++ b/docs/stdlib/design.md
@@ -14,7 +14,7 @@ The standard library is written in Run itself, not in Zig or C. This is the stan
 │  user-readable, contributable           │
 ├─────────────────────────────────────────┤
 │  Layer 2: Compiler Builtins (bridge)    │
-│  @syscall, @alloc, @chanSend, ...       │
+│  syscall, @alloc, @chanSend, ...       │
 │  Thin intrinsics the compiler lowers    │
 │  to C runtime calls                     │
 ├─────────────────────────────────────────┤
@@ -49,10 +49,10 @@ A small, fixed set of intrinsics that the compiler recognizes and lowers to C ru
 
 ```run
 // These are compiler-known, not user-definable
-@syscall.open(path, flags, mode)   // → run_syscall_open()
-@syscall.read(fd, buf, len)        // → run_syscall_read()
-@syscall.write(fd, buf, len)       // → run_syscall_write()
-@syscall.close(fd)                 // → run_syscall_close()
+syscall.open(path, flags, mode)   // → run_syscall_open()
+syscall.read(fd, buf, len)        // → run_syscall_read()
+syscall.write(fd, buf, len)       // → run_syscall_write()
+syscall.close(fd)                 // → run_syscall_close()
 @alloc(T)                          // → run_alloc(sizeof(T))
 @free(ptr)                         // → run_free(ptr)
 @chanSend(ch, val)                 // → run_chan_send()
@@ -143,23 +143,23 @@ pub type File struct {
 
 // Open opens a file for reading.
 pub fun open(path string) !File {
-    fd := try @syscall.open(path, O_RDONLY, 0)
+    fd := try syscall.open(path, O_RDONLY, 0)
     return File{ fd: fd, path: path }
 }
 
 // Read reads up to len(buf) bytes into buf.
 pub fun (f &File) read(buf []byte) !int {
-    return try @syscall.read(f.fd, buf, len(buf))
+    return try syscall.read(f.fd, buf, len(buf))
 }
 
 // Write writes buf to the file.
 pub fun (f &File) write(buf []byte) !int {
-    return try @syscall.write(f.fd, buf, len(buf))
+    return try syscall.write(f.fd, buf, len(buf))
 }
 
 // Close closes the file.
 pub fun (f &File) close() !void {
-    try @syscall.close(f.fd)
+    try syscall.close(f.fd)
 }
 ```
 

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -309,7 +309,7 @@ test "lex simple variable declaration" {
 }
 
 test "lex keywords" {
-    var lexer = Lexer.init("fn pub var let return package use struct map alloc import");
+    var lexer = Lexer.init("fn pub var let return package use struct map alloc syscall import");
     try std.testing.expectEqual(Tag.kw_fun, lexer.next().tag);
     try std.testing.expectEqual(Tag.kw_pub, lexer.next().tag);
     try std.testing.expectEqual(Tag.kw_var, lexer.next().tag);
@@ -320,6 +320,7 @@ test "lex keywords" {
     try std.testing.expectEqual(Tag.kw_struct, lexer.next().tag);
     try std.testing.expectEqual(Tag.kw_map, lexer.next().tag);
     try std.testing.expectEqual(Tag.kw_alloc, lexer.next().tag);
+    try std.testing.expectEqual(Tag.kw_syscall, lexer.next().tag);
     try std.testing.expectEqual(Tag.identifier, lexer.next().tag);
     try std.testing.expectEqual(Tag.eof, lexer.next().tag);
 }

--- a/src/lower.zig
+++ b/src/lower.zig
@@ -1215,6 +1215,37 @@ const LoweringContext = struct {
 
         if (std.mem.eql(u8, package_name, "unsafe") and std.mem.eql(u8, member_name, "alignof")) return "unsafe.alignof";
 
+        if (std.mem.eql(u8, package_name, "syscall")) {
+            if (std.mem.eql(u8, member_name, "open")) return "syscall.open";
+            if (std.mem.eql(u8, member_name, "read")) return "syscall.read";
+            if (std.mem.eql(u8, member_name, "write")) return "syscall.write";
+            if (std.mem.eql(u8, member_name, "close")) return "syscall.close";
+            if (std.mem.eql(u8, member_name, "lseek")) return "syscall.lseek";
+            if (std.mem.eql(u8, member_name, "args")) return "syscall.args";
+            if (std.mem.eql(u8, member_name, "getenv")) return "syscall.getenv";
+            if (std.mem.eql(u8, member_name, "setenv")) return "syscall.setenv";
+            if (std.mem.eql(u8, member_name, "unsetenv")) return "syscall.unsetenv";
+            if (std.mem.eql(u8, member_name, "environ")) return "syscall.environ";
+            if (std.mem.eql(u8, member_name, "exit")) return "syscall.exit";
+            if (std.mem.eql(u8, member_name, "getpid")) return "syscall.getpid";
+            if (std.mem.eql(u8, member_name, "gethostname")) return "syscall.gethostname";
+            if (std.mem.eql(u8, member_name, "mkdir")) return "syscall.mkdir";
+            if (std.mem.eql(u8, member_name, "rmdir")) return "syscall.rmdir";
+            if (std.mem.eql(u8, member_name, "unlink")) return "syscall.unlink";
+            if (std.mem.eql(u8, member_name, "rename")) return "syscall.rename";
+            if (std.mem.eql(u8, member_name, "symlink")) return "syscall.symlink";
+            if (std.mem.eql(u8, member_name, "readlink")) return "syscall.readlink";
+            if (std.mem.eql(u8, member_name, "chmod")) return "syscall.chmod";
+            if (std.mem.eql(u8, member_name, "chown")) return "syscall.chown";
+            if (std.mem.eql(u8, member_name, "stat")) return "syscall.stat";
+            if (std.mem.eql(u8, member_name, "lstat")) return "syscall.lstat";
+            if (std.mem.eql(u8, member_name, "readdir")) return "syscall.readdir";
+            if (std.mem.eql(u8, member_name, "mkstemp")) return "syscall.mkstemp";
+            if (std.mem.eql(u8, member_name, "getcwd")) return "syscall.getcwd";
+            if (std.mem.eql(u8, member_name, "chdir")) return "syscall.chdir";
+            return null;
+        }
+
         if (std.mem.eql(u8, package_name, "numa")) {
             if (std.mem.eql(u8, member_name, "node_count")) return "numa.node_count";
             if (std.mem.eql(u8, member_name, "current_node")) return "numa.current_node";
@@ -1741,6 +1772,34 @@ const LoweringContext = struct {
         if (std.mem.eql(u8, name, "signal.stop")) return "run_signal_stop";
         if (std.mem.eql(u8, name, "signal.ignore")) return "run_signal_ignore";
         if (std.mem.eql(u8, name, "signal.reset")) return "run_signal_reset";
+        // syscall builtins
+        if (std.mem.eql(u8, name, "syscall.open")) return "run_syscall_open";
+        if (std.mem.eql(u8, name, "syscall.read")) return "run_syscall_read";
+        if (std.mem.eql(u8, name, "syscall.write")) return "run_syscall_write";
+        if (std.mem.eql(u8, name, "syscall.close")) return "run_syscall_close";
+        if (std.mem.eql(u8, name, "syscall.lseek")) return "run_syscall_lseek";
+        if (std.mem.eql(u8, name, "syscall.args")) return "run_syscall_args";
+        if (std.mem.eql(u8, name, "syscall.getenv")) return "run_syscall_getenv";
+        if (std.mem.eql(u8, name, "syscall.setenv")) return "run_syscall_setenv";
+        if (std.mem.eql(u8, name, "syscall.unsetenv")) return "run_syscall_unsetenv";
+        if (std.mem.eql(u8, name, "syscall.environ")) return "run_syscall_environ";
+        if (std.mem.eql(u8, name, "syscall.exit")) return "run_syscall_exit";
+        if (std.mem.eql(u8, name, "syscall.getpid")) return "run_syscall_getpid";
+        if (std.mem.eql(u8, name, "syscall.gethostname")) return "run_syscall_gethostname";
+        if (std.mem.eql(u8, name, "syscall.mkdir")) return "run_syscall_mkdir";
+        if (std.mem.eql(u8, name, "syscall.rmdir")) return "run_syscall_rmdir";
+        if (std.mem.eql(u8, name, "syscall.unlink")) return "run_syscall_unlink";
+        if (std.mem.eql(u8, name, "syscall.rename")) return "run_syscall_rename";
+        if (std.mem.eql(u8, name, "syscall.symlink")) return "run_syscall_symlink";
+        if (std.mem.eql(u8, name, "syscall.readlink")) return "run_syscall_readlink";
+        if (std.mem.eql(u8, name, "syscall.chmod")) return "run_syscall_chmod";
+        if (std.mem.eql(u8, name, "syscall.chown")) return "run_syscall_chown";
+        if (std.mem.eql(u8, name, "syscall.stat")) return "run_syscall_stat";
+        if (std.mem.eql(u8, name, "syscall.lstat")) return "run_syscall_lstat";
+        if (std.mem.eql(u8, name, "syscall.readdir")) return "run_syscall_readdir";
+        if (std.mem.eql(u8, name, "syscall.mkstemp")) return "run_syscall_mkstemp";
+        if (std.mem.eql(u8, name, "syscall.getcwd")) return "run_syscall_getcwd";
+        if (std.mem.eql(u8, name, "syscall.chdir")) return "run_syscall_chdir";
         return name;
     }
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1494,7 +1494,7 @@ pub const Parser = struct {
                     .data = .{ .lhs = null_node, .rhs = null_node },
                 });
             },
-            .identifier => {
+            .identifier, .kw_syscall => {
                 const tok = self.pos;
                 self.advance();
                 return self.tree.addNode(.{
@@ -2553,6 +2553,28 @@ test "parse anonymous struct with newline-separated fields" {
         if (node.tag == .field_decl) field_count += 1;
     }
     try std.testing.expectEqual(@as(u32, 3), field_count);
+}
+
+test "parse syscall keyword builtin call" {
+    const source = "fn main() {\n    _ = syscall.getpid()\n}";
+    var lexer = Lexer.init(source);
+    var tokens = try lexer.tokenize(std.testing.allocator);
+    defer tokens.deinit(std.testing.allocator);
+
+    var parser = Parser.init(std.testing.allocator, tokens.items, source);
+    defer parser.deinit();
+
+    _ = try parser.parseFile();
+    try std.testing.expectEqual(@as(usize, 0), parser.tree.errors.items.len);
+
+    var found_call = false;
+    var found_field_access = false;
+    for (parser.tree.nodes.items) |node| {
+        if (node.tag == .call) found_call = true;
+        if (node.tag == .field_access) found_field_access = true;
+    }
+    try std.testing.expect(found_call);
+    try std.testing.expect(found_field_access);
 }
 
 test "parse pointer to anonymous struct type" {

--- a/src/token.zig
+++ b/src/token.zig
@@ -52,6 +52,7 @@ pub const Token = struct {
         kw_not,
         kw_asm,
         kw_clobber,
+        kw_syscall,
 
         // Operators
         plus, // +
@@ -98,7 +99,7 @@ pub const Token = struct {
 
         pub fn isKeyword(tag: Tag) bool {
             return @intFromEnum(tag) >= @intFromEnum(Tag.kw_fun) and
-                @intFromEnum(tag) <= @intFromEnum(Tag.kw_clobber);
+                @intFromEnum(tag) <= @intFromEnum(Tag.kw_syscall);
         }
     };
 
@@ -136,6 +137,7 @@ pub const Token = struct {
         .{ "not", .kw_not },
         .{ "asm", .kw_asm },
         .{ "clobber", .kw_clobber },
+        .{ "syscall", .kw_syscall },
     });
 
     pub fn getKeyword(bytes: []const u8) ?Tag {

--- a/src/typecheck.zig
+++ b/src/typecheck.zig
@@ -1713,6 +1713,36 @@ const TypeChecker = struct {
         const member_name = self.tokenSlice(self.nodeMainToken(callee_node) + 1);
 
         if (std.mem.eql(u8, package_name, "unsafe") and std.mem.eql(u8, member_name, "alignof")) return "unsafe.alignof";
+        if (std.mem.eql(u8, package_name, "syscall")) {
+            if (std.mem.eql(u8, member_name, "open")) return "syscall.open";
+            if (std.mem.eql(u8, member_name, "read")) return "syscall.read";
+            if (std.mem.eql(u8, member_name, "write")) return "syscall.write";
+            if (std.mem.eql(u8, member_name, "close")) return "syscall.close";
+            if (std.mem.eql(u8, member_name, "lseek")) return "syscall.lseek";
+            if (std.mem.eql(u8, member_name, "args")) return "syscall.args";
+            if (std.mem.eql(u8, member_name, "getenv")) return "syscall.getenv";
+            if (std.mem.eql(u8, member_name, "setenv")) return "syscall.setenv";
+            if (std.mem.eql(u8, member_name, "unsetenv")) return "syscall.unsetenv";
+            if (std.mem.eql(u8, member_name, "environ")) return "syscall.environ";
+            if (std.mem.eql(u8, member_name, "exit")) return "syscall.exit";
+            if (std.mem.eql(u8, member_name, "getpid")) return "syscall.getpid";
+            if (std.mem.eql(u8, member_name, "gethostname")) return "syscall.gethostname";
+            if (std.mem.eql(u8, member_name, "mkdir")) return "syscall.mkdir";
+            if (std.mem.eql(u8, member_name, "rmdir")) return "syscall.rmdir";
+            if (std.mem.eql(u8, member_name, "unlink")) return "syscall.unlink";
+            if (std.mem.eql(u8, member_name, "rename")) return "syscall.rename";
+            if (std.mem.eql(u8, member_name, "symlink")) return "syscall.symlink";
+            if (std.mem.eql(u8, member_name, "readlink")) return "syscall.readlink";
+            if (std.mem.eql(u8, member_name, "chmod")) return "syscall.chmod";
+            if (std.mem.eql(u8, member_name, "chown")) return "syscall.chown";
+            if (std.mem.eql(u8, member_name, "stat")) return "syscall.stat";
+            if (std.mem.eql(u8, member_name, "lstat")) return "syscall.lstat";
+            if (std.mem.eql(u8, member_name, "readdir")) return "syscall.readdir";
+            if (std.mem.eql(u8, member_name, "mkstemp")) return "syscall.mkstemp";
+            if (std.mem.eql(u8, member_name, "getcwd")) return "syscall.getcwd";
+            if (std.mem.eql(u8, member_name, "chdir")) return "syscall.chdir";
+            return null;
+        }
         if (!std.mem.eql(u8, package_name, "simd")) return null;
         if (std.mem.eql(u8, member_name, "hadd")) return "simd.hadd";
         if (std.mem.eql(u8, member_name, "dot")) return "simd.dot";

--- a/stdlib/os/os.run
+++ b/stdlib/os/os.run
@@ -50,35 +50,35 @@ pub File struct {
 
 // open opens a file for reading.
 pub fun open(path string) !File {
-    fd := try @syscall.open(path, 0, 0)
+    fd := try syscall.open(path, 0, 0)
     return File{ fd: fd, path: path }
 }
 
 // create creates or truncates a file for writing.
 pub fun create(path string) !File {
-    fd := try @syscall.open(path, 577, 438)
+    fd := try syscall.open(path, 577, 438)
     return File{ fd: fd, path: path }
 }
 
 // open_file opens a file with the specified flags and permission mode.
 pub fun open_file(path string, flags int, mode int) !File {
-    fd := try @syscall.open(path, flags, mode)
+    fd := try syscall.open(path, flags, mode)
     return File{ fd: fd, path: path }
 }
 
 // read reads up to len(buf) bytes into buf.
 pub fun (f &File) read(buf []byte) !int {
-    return try @syscall.read(f.fd, buf, len(buf))
+    return try syscall.read(f.fd, buf, len(buf))
 }
 
 // write writes buf to the file.
 pub fun (f &File) write(buf []byte) !int {
-    return try @syscall.write(f.fd, buf, len(buf))
+    return try syscall.write(f.fd, buf, len(buf))
 }
 
 // close closes the file.
 pub fun (f &File) close() !void {
-    try @syscall.close(f.fd)
+    try syscall.close(f.fd)
 }
 
 // seek sets the offset for the next read or write on the file.
@@ -89,7 +89,7 @@ pub fun (f &File) seek(offset int, whence io.SeekWhence) !int {
         .current :: { w = 1 },
         .end :: { w = 2 },
     }
-    return try @syscall.lseek(f.fd, offset, w)
+    return try syscall.lseek(f.fd, offset, w)
 }
 
 // stdin is the standard input file.
@@ -103,44 +103,44 @@ pub var stderr = File{ fd: 2, path: "<stderr>" }
 
 // args returns the command-line arguments, starting with the program name.
 pub fun args() []string {
-    return @syscall.args()
+    return syscall.args()
 }
 
 // getenv returns the value of the environment variable named by key,
 // or null if the variable is not set.
 pub fun getenv(key string) string? {
-    return @syscall.getenv(key)
+    return syscall.getenv(key)
 }
 
 // setenv sets the value of the environment variable named by key.
 pub fun setenv(key string, value string) !void {
-    try @syscall.setenv(key, value)
+    try syscall.setenv(key, value)
 }
 
 // unsetenv removes the environment variable named by key.
 pub fun unsetenv(key string) !void {
-    try @syscall.unsetenv(key)
+    try syscall.unsetenv(key)
 }
 
 // environ returns all environment variables as a slice of "KEY=VALUE" strings.
 pub fun environ() []string {
-    return @syscall.environ()
+    return syscall.environ()
 }
 
 // exit terminates the program with the given exit code.
 pub fun exit(code int) {
-    @syscall.exit(code)
+    syscall.exit(code)
 }
 
 // getpid returns the process ID of the current process.
 pub fun getpid() int {
-    return @syscall.getpid()
+    return syscall.getpid()
 }
 
 // hostname returns the hostname of the machine.
 pub fun hostname() !string {
     var buf = alloc([]byte, 256)
-    let n = try @syscall.gethostname(buf, 256)
+    let n = try syscall.gethostname(buf, 256)
     return string(buf[0..n])
 }
 
@@ -155,7 +155,7 @@ pub fun user_home_dir() !string {
 
 // mkdir creates a directory at the given path with permission 0755.
 pub fun mkdir(path string) !void {
-    try @syscall.mkdir(path, 493)
+    try syscall.mkdir(path, 493)
 }
 
 // mkdir_all creates a directory path, including any missing parents.
@@ -171,17 +171,17 @@ pub fun mkdir_all(path string) !void {
     if len(parent) > 0 and parent != cleaned {
         try mkdir_all(parent)
     }
-    try @syscall.mkdir(cleaned, 493)
+    try syscall.mkdir(cleaned, 493)
 }
 
 // remove removes the named file or empty directory.
 pub fun remove(path string) !void {
     let info = try lstat(path)
     if info.is_dir {
-        try @syscall.rmdir(path)
+        try syscall.rmdir(path)
         return
     }
-    try @syscall.unlink(path)
+    try syscall.unlink(path)
 }
 
 // remove_all removes the path and any children it contains.
@@ -193,42 +193,42 @@ pub fun remove_all(path string) !void {
             let child = join_path([path, entry.name])
             try remove_all(child)
         }
-        try @syscall.rmdir(path)
+        try syscall.rmdir(path)
     } else {
-        try @syscall.unlink(path)
+        try syscall.unlink(path)
     }
 }
 
 // rename renames (moves) a file or directory from old_path to new_path.
 pub fun rename(old_path string, new_path string) !void {
-    try @syscall.rename(old_path, new_path)
+    try syscall.rename(old_path, new_path)
 }
 
 // symlink creates a symbolic link that points to target.
 pub fun symlink(target string, link string) !void {
-    try @syscall.symlink(target, link)
+    try syscall.symlink(target, link)
 }
 
 // read_link returns the destination of the named symbolic link.
 pub fun read_link(path string) !string {
     var buf = alloc([]byte, 1024)
-    let n = try @syscall.readlink(path, buf, 1024)
+    let n = try syscall.readlink(path, buf, 1024)
     return string(buf[0..n])
 }
 
 // chmod changes the permission bits of the named file.
 pub fun chmod(path string, mode int) !void {
-    try @syscall.chmod(path, mode)
+    try syscall.chmod(path, mode)
 }
 
 // chown changes the numeric uid and gid of the named file.
 pub fun chown(path string, uid int, gid int) !void {
-    try @syscall.chown(path, uid, gid)
+    try syscall.chown(path, uid, gid)
 }
 
 // stat returns file info for the named path.
 pub fun stat(path string) !FileInfo {
-    let raw = try @syscall.stat(path)
+    let raw = try syscall.stat(path)
     return FileInfo{
         name: base(path),
         size: raw.size,
@@ -240,7 +240,7 @@ pub fun stat(path string) !FileInfo {
 
 // lstat returns file info for the named path without following symlinks.
 pub fun lstat(path string) !FileInfo {
-    let raw = try @syscall.lstat(path)
+    let raw = try syscall.lstat(path)
     return FileInfo{
         name: base(path),
         size: raw.size,
@@ -252,7 +252,7 @@ pub fun lstat(path string) !FileInfo {
 
 // read_dir reads the named directory and returns a list of directory entries.
 pub fun read_dir(path string) ![]DirEntry {
-    let raw_entries = try @syscall.readdir(path)
+    let raw_entries = try syscall.readdir(path)
     var entries = alloc([]DirEntry, len(raw_entries))
     var i = 0
     for raw in raw_entries {
@@ -280,7 +280,7 @@ pub fun temp_dir() string {
 // removing the file.
 pub fun create_temp(prefix string) !File {
     let template = join_path([temp_dir(), prefix + "XXXXXX"])
-    let fd = try @syscall.mkstemp(template)
+    let fd = try syscall.mkstemp(template)
     return File{ fd: fd, path: template }
 }
 
@@ -291,7 +291,7 @@ pub fun temp_file(prefix string) !File {
 
 // cwd returns the current working directory.
 pub fun cwd() !string {
-    return try @syscall.getcwd()
+    return try syscall.getcwd()
 }
 
 // getwd is a backward-compatible alias for cwd.
@@ -301,7 +301,7 @@ pub fun getwd() !string {
 
 // chdir changes the current working directory.
 pub fun chdir(path string) !void {
-    try @syscall.chdir(path)
+    try syscall.chdir(path)
 }
 
 // read_file reads the entire contents of a file.
@@ -507,7 +507,7 @@ pub fun glob(pattern string) ![]string {
     return matches
 }
 
-// mode_from_raw converts a raw mode type integer from @syscall.stat
+// mode_from_raw converts a raw mode type integer from syscall.stat
 // to a FileMode sum type value.
 fun mode_from_raw(raw_type int) FileMode {
     switch raw_type {


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc `@syscall` call syntax with a dedicated `syscall` keyword to make syscall intrinsics a first-class, clearer builtin namespace. 
- Ensure compiler/front-end recognizes `syscall.<name>()` as compiler-known intrinsics and lower them to existing runtime entrypoints.

### Description
- Add `kw_syscall` to the token model and keyword table and update the lexer tests to include the new keyword (`src/token.zig`, `src/lexer.zig`).
- Teach the parser to accept `kw_syscall` as an identifier-like primary so expressions like `syscall.getpid()` parse as `field_access` + `call` (parser change + new parser unit test) (`src/parser.zig`).
- Extend builtin recognition in the type checker and lowering stages so `syscall.<member>` maps to `syscall.<member>` builtin names and the lowering maps those to the existing `run_syscall_*` runtime helpers (`src/typecheck.zig`, `src/lower.zig`).
- Update the standard library and docs to use the new syntax (`syscall.*`) instead of `@syscall.*` and adjust related comments (`stdlib/os/os.run`, `docs/stdlib/design.md`).

### Testing
- Verified source edits and replacements with a repository search using `rg -n "@syscall|\bsyscall\."` to confirm `@syscall` occurrences were replaced; this check succeeded.
- Added a parser unit test for `syscall.getpid()` parsing but the full test suite was not executed because `zig` is not installed in the environment (attempted `zig fmt` / `zig` calls failed). 
- Could not create or attach a GitHub issue from this environment because there is no configured remote and `gh`/auth token are unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0418121d8832cab8783722cc3e232)