### PR TITLE
stdlib: implement strings, bytes, iter, slices, maps, cmp packages

### DIFF
--- a/stdlib/bytes/bytes.run
+++ b/stdlib/bytes/bytes.run
@@ -15,100 +15,320 @@ pub Buffer struct {
 
 // read reads from the buffer into buf. Returns the number of bytes read.
 pub fun (b &Buffer) read(buf []byte) !int {
-    return 0
+    if b.pos >= len(b.buf) {
+        return 0
+    }
+    var available = len(b.buf) - b.pos
+    var n = available
+    if n > len(buf) {
+        n = len(buf)
+    }
+    var i = 0
+    for i < n {
+        buf[i] = b.buf[b.pos + i]
+        i = i + 1
+    }
+    b.pos = b.pos + n
+    return n
 }
 
 // write appends data to the buffer. Returns the number of bytes written.
 pub fun (b &Buffer) write(data []byte) !int {
-    return 0
+    var i = 0
+    for i < len(data) {
+        b.buf = append(b.buf, data[i])
+        i = i + 1
+    }
+    return len(data)
 }
 
 // writeString appends the contents of s to the buffer.
 pub fun (b &Buffer) writeString(s string) !int {
-    return 0
+    var data = s as []byte
+    var i = 0
+    for i < len(data) {
+        b.buf = append(b.buf, data[i])
+        i = i + 1
+    }
+    return len(data)
 }
 
 // writeByte appends a single byte to the buffer.
 pub fun (b &Buffer) writeByte(c byte) !void {
+    b.buf = append(b.buf, c)
 }
 
 // bytes returns the unread portion of the buffer as a byte slice.
 pub fun (b @Buffer) bytes() []byte {
-    return alloc([]byte, 0)
+    return b.buf[b.pos..len(b.buf)]
 }
 
 // string returns the unread portion of the buffer as a string.
 pub fun (b @Buffer) string() string {
-    return ""
+    return b.buf[b.pos..len(b.buf)] as string
 }
 
 // reset resets the buffer to be empty.
 pub fun (b &Buffer) reset() {
+    b.buf = alloc([]byte, 0)
+    b.pos = 0
 }
 
 // len returns the number of unread bytes in the buffer.
 pub fun (b @Buffer) len() int {
-    return 0
+    return len(b.buf) - b.pos
 }
 
 // cap returns the capacity of the buffer's underlying byte slice.
 pub fun (b @Buffer) cap() int {
-    return 0
+    return len(b.buf)
 }
 
 // contains reports whether sub is within b.
 pub fun contains(b []byte, sub []byte) bool {
-    return false
+    return index(b, sub) != null
 }
 
 // index returns the index of the first instance of sub in b,
 // or null if sub is not present.
 pub fun index(b []byte, sub []byte) int? {
+    if len(sub) == 0 {
+        return .some(0)
+    }
+    if len(sub) > len(b) {
+        return null
+    }
+    var i = 0
+    var limit = len(b) - len(sub)
+    for i <= limit {
+        var j = 0
+        var match = true
+        for j < len(sub) {
+            if b[i + j] != sub[j] {
+                match = false
+                break
+            }
+            j = j + 1
+        }
+        if match {
+            return .some(i)
+        }
+        i = i + 1
+    }
     return null
 }
 
 // split slices b into all subslices separated by sep.
 pub fun split(b []byte, sep []byte) [][]byte {
-    return alloc([][]byte, 0)
+    var result = alloc([][]byte, 0)
+    if len(sep) == 0 {
+        // Split into individual bytes.
+        var i = 0
+        for i < len(b) {
+            var single = alloc([]byte, 1)
+            single[0] = b[i]
+            result = append(result, single)
+            i = i + 1
+        }
+        return result
+    }
+    var pos = 0
+    for pos <= len(b) {
+        // Search for sep starting at pos.
+        var found = false
+        var idx = pos
+        for idx <= len(b) - len(sep) {
+            var j = 0
+            var match = true
+            for j < len(sep) {
+                if b[idx + j] != sep[j] {
+                    match = false
+                    break
+                }
+                j = j + 1
+            }
+            if match {
+                found = true
+                break
+            }
+            idx = idx + 1
+        }
+        if found {
+            result = append(result, b[pos..idx])
+            pos = idx + len(sep)
+        } else {
+            break
+        }
+    }
+    result = append(result, b[pos..len(b)])
+    return result
 }
 
 // join concatenates the elements of parts with sep between each element.
 pub fun join(parts [][]byte, sep []byte) []byte {
-    return alloc([]byte, 0)
+    if len(parts) == 0 {
+        return alloc([]byte, 0)
+    }
+    // Calculate total length.
+    var total = 0
+    var i = 0
+    for i < len(parts) {
+        if i > 0 {
+            total = total + len(sep)
+        }
+        total = total + len(parts[i])
+        i = i + 1
+    }
+    var result = alloc([]byte, 0)
+    i = 0
+    for i < len(parts) {
+        if i > 0 {
+            var j = 0
+            for j < len(sep) {
+                result = append(result, sep[j])
+                j = j + 1
+            }
+        }
+        var j = 0
+        for j < len(parts[i]) {
+            result = append(result, parts[i][j])
+            j = j + 1
+        }
+        i = i + 1
+    }
+    return result
+}
+
+fun isWhitespace(c byte) bool {
+    if c == 32 {
+        return true
+    }
+    if c == 9 {
+        return true
+    }
+    if c == 10 {
+        return true
+    }
+    if c == 13 {
+        return true
+    }
+    return false
 }
 
 // trim returns b with leading and trailing whitespace removed.
 pub fun trim(b []byte) []byte {
-    return alloc([]byte, 0)
+    var start = 0
+    for start < len(b) {
+        if !isWhitespace(b[start]) {
+            break
+        }
+        start = start + 1
+    }
+    var end = len(b)
+    for end > start {
+        if !isWhitespace(b[end - 1]) {
+            break
+        }
+        end = end - 1
+    }
+    return b[start..end]
 }
 
 // equal reports whether a and b are the same length and contain
 // the same bytes.
 pub fun equal(a []byte, b []byte) bool {
-    return false
+    if len(a) != len(b) {
+        return false
+    }
+    var i = 0
+    for i < len(a) {
+        if a[i] != b[i] {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // hasPrefix reports whether b begins with prefix.
 pub fun hasPrefix(b []byte, prefix []byte) bool {
-    return false
+    if len(prefix) > len(b) {
+        return false
+    }
+    var i = 0
+    for i < len(prefix) {
+        if b[i] != prefix[i] {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // hasSuffix reports whether b ends with suffix.
 pub fun hasSuffix(b []byte, suffix []byte) bool {
-    return false
+    if len(suffix) > len(b) {
+        return false
+    }
+    var offset = len(b) - len(suffix)
+    var i = 0
+    for i < len(suffix) {
+        if b[offset + i] != suffix[i] {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // repeat returns a new byte slice consisting of count copies of b.
 pub fun repeat(b []byte, count int) []byte {
-    return alloc([]byte, 0)
+    if count <= 0 {
+        return alloc([]byte, 0)
+    }
+    var result = alloc([]byte, 0)
+    var i = 0
+    for i < count {
+        var j = 0
+        for j < len(b) {
+            result = append(result, b[j])
+            j = j + 1
+        }
+        i = i + 1
+    }
+    return result
 }
 
 // toLower returns a copy of b with all ASCII letters mapped to lower case.
 pub fun toLower(b []byte) []byte {
-    return alloc([]byte, 0)
+    var result = alloc([]byte, len(b))
+    var i = 0
+    for i < len(b) {
+        var c = b[i]
+        if c >= 65 {
+            if c <= 90 {
+                c = c + 32
+            }
+        }
+        result[i] = c
+        i = i + 1
+    }
+    return result
 }
 
 // toUpper returns a copy of b with all ASCII letters mapped to upper case.
 pub fun toUpper(b []byte) []byte {
-    return alloc([]byte, 0)
+    var result = alloc([]byte, len(b))
+    var i = 0
+    for i < len(b) {
+        var c = b[i]
+        if c >= 97 {
+            if c <= 122 {
+                c = c - 32
+            }
+        }
+        result[i] = c
+        i = i + 1
+    }
+    return result
 }

--- a/stdlib/cmp/cmp.run
+++ b/stdlib/cmp/cmp.run
@@ -10,26 +10,94 @@ pub type Ordered interface {
 }
 
 // compare compares two values and returns an Ordering.
+// If both values implement Ordered, uses that interface.
+// Otherwise falls back to built-in type comparisons for int, f64, and string.
 pub fun compare(a any, b any) Ordering {
+    // Try the Ordered interface first.
+    var ao = a as Ordered
+    if ao != null {
+        return ao.compare(b)
+    }
+
+    // Fallback: compare built-in types.
+    var ai = a as int
+    var bi = b as int
+    if ai != null {
+        if bi != null {
+            if ai < bi {
+                return .less
+            }
+            if ai > bi {
+                return .greater
+            }
+            return .equal
+        }
+    }
+
+    var af = a as f64
+    var bf = b as f64
+    if af != null {
+        if bf != null {
+            if af < bf {
+                return .less
+            }
+            if af > bf {
+                return .greater
+            }
+            return .equal
+        }
+    }
+
+    var as_ = a as string
+    var bs = b as string
+    if as_ != null {
+        if bs != null {
+            if as_ < bs {
+                return .less
+            }
+            if as_ > bs {
+                return .greater
+            }
+            return .equal
+        }
+    }
+
     return .equal
 }
 
 // min returns the smaller of a or b.
 // If equal, returns a.
 pub fun min(a any, b any) any {
-    return a
+    var ord = compare(a, b)
+    switch ord {
+        .greater :: { return b },
+        _ :: { return a },
+    }
 }
 
 // max returns the larger of a or b.
 // If equal, returns a.
 pub fun max(a any, b any) any {
-    return a
+    var ord = compare(a, b)
+    switch ord {
+        .less :: { return b },
+        _ :: { return a },
+    }
 }
 
 // clamp returns val constrained to the range [lo, hi].
 // Panics if lo > hi.
 pub fun clamp(val any, lo any, hi any) any {
-    return val
+    var ord = compare(val, lo)
+    switch ord {
+        .less :: { return lo },
+        _ :: {},
+    }
+    var ord2 = compare(val, hi)
+    switch ord2 {
+        .greater :: { return hi },
+        _ :: { return val },
+    }
 }
 
 // minInt returns the smaller of a or b.

--- a/stdlib/iter/iter.run
+++ b/stdlib/iter/iter.run
@@ -6,93 +6,413 @@ pub type Iterator interface {
     next() any?
 }
 
+// Pair holds an index-value or key-value pair for enumerate and zip.
+pub Pair struct {
+    first  any
+    second any
+}
+
+// --- Private iterator structs ---
+
+SliceIterator struct {
+    implements {
+        Iterator
+    }
+
+    items []any
+    pos   int
+}
+
+fun (it &SliceIterator) next() any? {
+    if it.pos >= len(it.items) {
+        return null
+    }
+    var val = it.items[it.pos]
+    it.pos = it.pos + 1
+    return .some(val)
+}
+
+RangeIterator struct {
+    implements {
+        Iterator
+    }
+
+    current int
+    end     int
+}
+
+fun (it &RangeIterator) next() any? {
+    if it.current >= it.end {
+        return null
+    }
+    var val = it.current
+    it.current = it.current + 1
+    return .some(val)
+}
+
+MapIterator struct {
+    implements {
+        Iterator
+    }
+
+    source Iterator
+    f      fun(any) any
+}
+
+fun (it &MapIterator) next() any? {
+    var val = it.source.next()
+    if val == null {
+        return null
+    }
+    return .some(it.f(val!))
+}
+
+FilterIterator struct {
+    implements {
+        Iterator
+    }
+
+    source Iterator
+    f      fun(any) bool
+}
+
+fun (it &FilterIterator) next() any? {
+    for {
+        var val = it.source.next()
+        if val == null {
+            return null
+        }
+        if it.f(val!) {
+            return val
+        }
+    }
+}
+
+TakeIterator struct {
+    implements {
+        Iterator
+    }
+
+    source    Iterator
+    remaining int
+}
+
+fun (it &TakeIterator) next() any? {
+    if it.remaining <= 0 {
+        return null
+    }
+    it.remaining = it.remaining - 1
+    return it.source.next()
+}
+
+SkipIterator struct {
+    implements {
+        Iterator
+    }
+
+    source    Iterator
+    remaining int
+    skipped   bool
+}
+
+fun (it &SkipIterator) next() any? {
+    if !it.skipped {
+        var i = 0
+        for i < it.remaining {
+            var val = it.source.next()
+            if val == null {
+                it.skipped = true
+                return null
+            }
+            i = i + 1
+        }
+        it.skipped = true
+    }
+    return it.source.next()
+}
+
+ZipIterator struct {
+    implements {
+        Iterator
+    }
+
+    a Iterator
+    b Iterator
+}
+
+fun (it &ZipIterator) next() any? {
+    var va = it.a.next()
+    var vb = it.b.next()
+    if va == null {
+        return null
+    }
+    if vb == null {
+        return null
+    }
+    return .some(Pair{ first: va!, second: vb! })
+}
+
+ChainIterator struct {
+    implements {
+        Iterator
+    }
+
+    a     Iterator
+    b     Iterator
+    first bool
+}
+
+fun (it &ChainIterator) next() any? {
+    if it.first {
+        var val = it.a.next()
+        if val != null {
+            return val
+        }
+        it.first = false
+    }
+    return it.b.next()
+}
+
+EnumerateIterator struct {
+    implements {
+        Iterator
+    }
+
+    source Iterator
+    index  int
+}
+
+fun (it &EnumerateIterator) next() any? {
+    var val = it.source.next()
+    if val == null {
+        return null
+    }
+    var idx = it.index
+    it.index = it.index + 1
+    return .some(Pair{ first: idx, second: val! })
+}
+
+FlatMapIterator struct {
+    implements {
+        Iterator
+    }
+
+    source  Iterator
+    f       fun(any) Iterator
+    current Iterator
+    started bool
+}
+
+fun (it &FlatMapIterator) next() any? {
+    for {
+        if it.started {
+            if it.current != null {
+                var val = it.current.next()
+                if val != null {
+                    return val
+                }
+            }
+        }
+        // Get next inner iterator from source.
+        var outer = it.source.next()
+        if outer == null {
+            return null
+        }
+        it.current = it.f(outer!)
+        it.started = true
+    }
+}
+
+TakeWhileIterator struct {
+    implements {
+        Iterator
+    }
+
+    source Iterator
+    f      fun(any) bool
+    done   bool
+}
+
+fun (it &TakeWhileIterator) next() any? {
+    if it.done {
+        return null
+    }
+    var val = it.source.next()
+    if val == null {
+        it.done = true
+        return null
+    }
+    if !it.f(val!) {
+        it.done = true
+        return null
+    }
+    return val
+}
+
+SkipWhileIterator struct {
+    implements {
+        Iterator
+    }
+
+    source   Iterator
+    f        fun(any) bool
+    skipping bool
+}
+
+fun (it &SkipWhileIterator) next() any? {
+    if it.skipping {
+        for {
+            var val = it.source.next()
+            if val == null {
+                return null
+            }
+            if !it.f(val!) {
+                it.skipping = false
+                return val
+            }
+        }
+    }
+    return it.source.next()
+}
+
+// --- Public factory functions ---
+
 // fromSlice creates an iterator over the elements of a slice.
 pub fun fromSlice(s []any) Iterator {
-    return null
+    return SliceIterator{ items: s, pos: 0 }
 }
 
 // range creates an iterator over integers in [start, end).
 pub fun range(start int, end int) Iterator {
-    return null
+    return RangeIterator{ current: start, end: end }
 }
 
 // map returns an iterator that applies f to each element.
 pub fun map(it Iterator, f fun(any) any) Iterator {
-    return null
+    return MapIterator{ source: it, f: f }
 }
 
 // filter returns an iterator that yields only elements where f returns true.
 pub fun filter(it Iterator, f fun(any) bool) Iterator {
-    return null
+    return FilterIterator{ source: it, f: f }
 }
 
 // reduce reduces the iterator to a single value by applying f
 // to an accumulator and each element.
 pub fun reduce(it Iterator, init any, f fun(acc any, item any) any) any {
-    return null
+    var acc = init
+    for {
+        var val = it.next()
+        if val == null {
+            break
+        }
+        acc = f(acc, val!)
+    }
+    return acc
 }
 
 // take returns an iterator that yields at most n elements.
 pub fun take(it Iterator, n int) Iterator {
-    return null
+    return TakeIterator{ source: it, remaining: n }
 }
 
 // skip returns an iterator that skips the first n elements.
 pub fun skip(it Iterator, n int) Iterator {
-    return null
+    return SkipIterator{ source: it, remaining: n, skipped: false }
 }
 
-// zip combines two iterators element-wise into an iterator of pairs.
+// zip combines two iterators element-wise into an iterator of Pairs.
 pub fun zip(a Iterator, b Iterator) Iterator {
-    return null
+    return ZipIterator{ a: a, b: b }
 }
 
 // chain chains two iterators sequentially.
 pub fun chain(a Iterator, b Iterator) Iterator {
-    return null
+    return ChainIterator{ a: a, b: b, first: true }
 }
 
-// enumerate wraps an iterator to yield (index, item) pairs.
+// enumerate wraps an iterator to yield Pair{index, item} values.
 pub fun enumerate(it Iterator) Iterator {
-    return null
+    return EnumerateIterator{ source: it, index: 0 }
 }
 
 // count consumes the iterator and returns the number of elements.
 pub fun count(it Iterator) int {
-    return 0
+    var n = 0
+    for {
+        var val = it.next()
+        if val == null {
+            break
+        }
+        n = n + 1
+    }
+    return n
 }
 
 // anyMatch reports whether f returns true for any element.
 pub fun anyMatch(it Iterator, f fun(any) bool) bool {
+    for {
+        var val = it.next()
+        if val == null {
+            break
+        }
+        if f(val!) {
+            return true
+        }
+    }
     return false
 }
 
 // allMatch reports whether f returns true for all elements.
 pub fun allMatch(it Iterator, f fun(any) bool) bool {
-    return false
+    for {
+        var val = it.next()
+        if val == null {
+            break
+        }
+        if !f(val!) {
+            return false
+        }
+    }
+    return true
 }
 
 // collect consumes the iterator and collects all elements into a slice.
 pub fun collect(it Iterator) []any {
-    return alloc([]any, 0)
+    var result = alloc([]any, 0)
+    for {
+        var val = it.next()
+        if val == null {
+            break
+        }
+        result = append(result, val!)
+    }
+    return result
 }
 
 // forEach applies f to each element in the iterator.
 pub fun forEach(it Iterator, f fun(any)) {
+    for {
+        var val = it.next()
+        if val == null {
+            break
+        }
+        f(val!)
+    }
 }
 
 // flatMap applies f to each element and flattens the resulting iterators.
 pub fun flatMap(it Iterator, f fun(any) Iterator) Iterator {
-    return null
+    return FlatMapIterator{ source: it, f: f, current: null, started: false }
 }
 
 // takeWhile returns an iterator that yields elements while f returns true.
 pub fun takeWhile(it Iterator, f fun(any) bool) Iterator {
-    return null
+    return TakeWhileIterator{ source: it, f: f, done: false }
 }
 
 // skipWhile returns an iterator that skips elements while f returns true,
 // then yields the rest.
 pub fun skipWhile(it Iterator, f fun(any) bool) Iterator {
-    return null
+    return SkipWhileIterator{ source: it, f: f, skipping: true }
 }

--- a/stdlib/maps/maps.run
+++ b/stdlib/maps/maps.run
@@ -3,42 +3,100 @@ package maps
 // keys returns the keys of the map as a slice.
 // The order of keys is not guaranteed.
 pub fun keys(m map[any]any) []any {
-    return alloc([]any, 0)
+    var result = alloc([]any, 0)
+    for key, _ in m {
+        result = append(result, key)
+    }
+    return result
 }
 
 // values returns the values of the map as a slice.
 // The order of values is not guaranteed.
 pub fun values(m map[any]any) []any {
-    return alloc([]any, 0)
+    var result = alloc([]any, 0)
+    for _, value in m {
+        result = append(result, value)
+    }
+    return result
 }
 
 // clone returns a shallow copy of the map.
 pub fun clone(m map[any]any) map[any]any {
-    return alloc(map[any]any, 0)
+    var result = alloc(map[any]any, 0)
+    for key, value in m {
+        result[key] = value
+    }
+    return result
 }
 
 // equal reports whether two maps contain the same key/value pairs.
 pub fun equal(a map[any]any, b map[any]any) bool {
-    return false
+    // Check that every key in a exists in b with the same value.
+    for key, value in a {
+        var bv = b[key]
+        if bv == null {
+            return false
+        }
+        if bv != value {
+            return false
+        }
+    }
+    // Check that every key in b exists in a.
+    for key, _ in b {
+        var av = a[key]
+        if av == null {
+            return false
+        }
+    }
+    return true
 }
 
 // equalFunc reports whether two maps contain the same keys and
 // the values satisfy the provided equality function.
 pub fun equalFunc(a map[any]any, b map[any]any, eq fun(v1 any, v2 any) bool) bool {
-    return false
+    for key, va in a {
+        var vb = b[key]
+        if vb == null {
+            return false
+        }
+        if !eq(va, vb) {
+            return false
+        }
+    }
+    for key, _ in b {
+        var va = a[key]
+        if va == null {
+            return false
+        }
+    }
+    return true
 }
 
 // deleteFunc deletes all entries from m for which f returns true.
 pub fun deleteFunc(m map[any]any, f fun(key any, value any) bool) {
+    // Collect keys to delete first to avoid modifying map during iteration.
+    var toDelete = alloc([]any, 0)
+    for key, value in m {
+        if f(key, value) {
+            toDelete = append(toDelete, key)
+        }
+    }
+    for key in toDelete {
+        delete(m, key)
+    }
 }
 
 // copy copies all key/value pairs from src to dst.
 // When a key in src is already present in dst, the value in dst
 // is overwritten with the value from src.
 pub fun copy(dst map[any]any, src map[any]any) {
+    for key, value in src {
+        dst[key] = value
+    }
 }
 
 // has reports whether the map contains the given key.
 pub fun has(m map[any]any, key any) bool {
-    return false
+    var val = m[key]
+    return val != null
 }

--- a/stdlib/slices/slices.run
+++ b/stdlib/slices/slices.run
@@ -2,90 +2,264 @@ package slices
 
 // contains reports whether v is present in s.
 pub fun contains(s []any, v any) bool {
+    for item in s {
+        if item == v {
+            return true
+        }
+    }
     return false
 }
 
 // index returns the index of the first occurrence of v in s,
 // or null if v is not present.
 pub fun index(s []any, v any) int? {
+    var i = 0
+    for i < len(s) {
+        if s[i] == v {
+            return .some(i)
+        }
+        i = i + 1
+    }
     return null
 }
 
 // lastIndex returns the index of the last occurrence of v in s,
 // or null if v is not present.
 pub fun lastIndex(s []any, v any) int? {
+    var i = len(s) - 1
+    for i >= 0 {
+        if s[i] == v {
+            return .some(i)
+        }
+        i = i - 1
+    }
     return null
 }
 
 // compact removes consecutive duplicate elements from s.
 pub fun compact(s []any) []any {
-    return alloc([]any, 0)
+    if len(s) == 0 {
+        return alloc([]any, 0)
+    }
+    var result = alloc([]any, 0)
+    result = append(result, s[0])
+    var i = 1
+    for i < len(s) {
+        if s[i] != s[i - 1] {
+            result = append(result, s[i])
+        }
+        i = i + 1
+    }
+    return result
 }
 
 // sortFunc sorts s in-place using the provided comparison function.
 // cmp(a, b) should return a negative number when a < b, zero when a == b,
 // and a positive number when a > b.
+// Uses insertion sort for simplicity and correctness.
 pub fun sortFunc(s []any, cmp fun(a any, b any) int) {
+    var i = 1
+    for i < len(s) {
+        var key = s[i]
+        var j = i - 1
+        for j >= 0 {
+            if cmp(s[j], key) <= 0 {
+                break
+            }
+            s[j + 1] = s[j]
+            j = j - 1
+        }
+        s[j + 1] = key
+        i = i + 1
+    }
 }
 
 // isSortedFunc reports whether s is sorted according to the comparison function.
 pub fun isSortedFunc(s []any, cmp fun(a any, b any) int) bool {
-    return false
+    var i = 1
+    for i < len(s) {
+        if cmp(s[i - 1], s[i]) > 0 {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // reverse reverses the elements of s in place.
 pub fun reverse(s []any) {
+    var lo = 0
+    var hi = len(s) - 1
+    for lo < hi {
+        var tmp = s[lo]
+        s[lo] = s[hi]
+        s[hi] = tmp
+        lo = lo + 1
+        hi = hi - 1
+    }
 }
 
 // grow increases the capacity of s by at least n additional elements.
 pub fun grow(s []any, n int) []any {
-    return alloc([]any, 0)
+    var result = alloc([]any, len(s) + n)
+    var i = 0
+    for i < len(s) {
+        result[i] = s[i]
+        i = i + 1
+    }
+    return result
 }
 
 // insert inserts the value v at index i, shifting subsequent elements right.
 pub fun insert(s []any, i int, v any) []any {
-    return alloc([]any, 0)
+    var result = alloc([]any, len(s) + 1)
+    // Copy elements before i.
+    var j = 0
+    for j < i {
+        result[j] = s[j]
+        j = j + 1
+    }
+    // Insert the new value.
+    result[i] = v
+    // Copy elements after i.
+    j = i
+    for j < len(s) {
+        result[j + 1] = s[j]
+        j = j + 1
+    }
+    return result
 }
 
 // delete removes the element at index i from s.
 pub fun delete(s []any, i int) []any {
-    return alloc([]any, 0)
+    var result = alloc([]any, len(s) - 1)
+    // Copy elements before i.
+    var j = 0
+    for j < i {
+        result[j] = s[j]
+        j = j + 1
+    }
+    // Copy elements after i.
+    j = i + 1
+    for j < len(s) {
+        result[j - 1] = s[j]
+        j = j + 1
+    }
+    return result
 }
 
 // clone returns a shallow copy of s.
 pub fun clone(s []any) []any {
-    return alloc([]any, 0)
+    var result = alloc([]any, len(s))
+    var i = 0
+    for i < len(s) {
+        result[i] = s[i]
+        i = i + 1
+    }
+    return result
 }
 
 // equal reports whether two slices are equal: the same length and all
 // elements equal.
 pub fun equal(a []any, b []any) bool {
-    return false
+    if len(a) != len(b) {
+        return false
+    }
+    var i = 0
+    for i < len(a) {
+        if a[i] != b[i] {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // minFunc returns the minimum element of s according to the comparison function.
 pub fun minFunc(s []any, cmp fun(a any, b any) int) any {
-    return null
+    if len(s) == 0 {
+        return null
+    }
+    var result = s[0]
+    var i = 1
+    for i < len(s) {
+        if cmp(s[i], result) < 0 {
+            result = s[i]
+        }
+        i = i + 1
+    }
+    return result
 }
 
 // maxFunc returns the maximum element of s according to the comparison function.
 pub fun maxFunc(s []any, cmp fun(a any, b any) int) any {
-    return null
+    if len(s) == 0 {
+        return null
+    }
+    var result = s[0]
+    var i = 1
+    for i < len(s) {
+        if cmp(s[i], result) > 0 {
+            result = s[i]
+        }
+        i = i + 1
+    }
+    return result
 }
 
 // binarySearchFunc searches for target in a sorted slice using the
 // comparison function. Returns the index if found, or null.
 pub fun binarySearchFunc(s []any, target any, cmp fun(a any, b any) int) int? {
+    var lo = 0
+    var hi = len(s) - 1
+    for lo <= hi {
+        var mid = lo + (hi - lo) / 2
+        var c = cmp(s[mid], target)
+        if c == 0 {
+            return .some(mid)
+        }
+        if c < 0 {
+            lo = mid + 1
+        } else {
+            hi = mid - 1
+        }
+    }
     return null
 }
 
 // chunk splits s into sub-slices of the given size.
 // The last chunk may have fewer elements.
 pub fun chunk(s []any, size int) [][]any {
-    return alloc([][]any, 0)
+    if size <= 0 {
+        return alloc([][]any, 0)
+    }
+    var result = alloc([][]any, 0)
+    var i = 0
+    for i < len(s) {
+        var end = i + size
+        if end > len(s) {
+            end = len(s)
+        }
+        result = append(result, s[i..end])
+        i = i + size
+    }
+    return result
 }
 
 // concat returns a new slice concatenating the provided slices.
 pub fun concat(slices_list [][]any) []any {
-    return alloc([]any, 0)
+    // Calculate total length.
+    var total = 0
+    for sl in slices_list {
+        total = total + len(sl)
+    }
+    var result = alloc([]any, 0)
+    for sl in slices_list {
+        var i = 0
+        for i < len(sl) {
+            result = append(result, sl[i])
+            i = i + 1
+        }
+    }
+    return result
 }

--- a/stdlib/strings/strings.run
+++ b/stdlib/strings/strings.run
@@ -8,156 +8,594 @@ pub Builder struct {
 
 // writeString appends the contents of s to the builder's buffer.
 pub fun (b &Builder) writeString(s string) {
+    var data = s as []byte
+    var i = 0
+    for i < len(data) {
+        b.buf = append(b.buf, data[i])
+        i = i + 1
+    }
 }
 
 // writeByte appends a single byte to the builder's buffer.
 pub fun (b &Builder) writeByte(c byte) {
+    b.buf = append(b.buf, c)
 }
 
 // string returns the accumulated string and resets the builder.
 pub fun (b &Builder) string() string {
-    return ""
+    var result = b.buf as string
+    b.buf = alloc([]byte, 0)
+    return result
 }
 
 // reset resets the builder to be empty.
 pub fun (b &Builder) reset() {
+    b.buf = alloc([]byte, 0)
 }
 
 // len returns the number of accumulated bytes.
 pub fun (b @Builder) len() int {
-    return 0
+    return len(b.buf)
 }
 
 // contains reports whether substr is within s.
 pub fun contains(s string, substr string) bool {
-    return false
+    return indexOf(s, substr) != null
 }
 
 // hasPrefix reports whether s begins with prefix.
 pub fun hasPrefix(s string, prefix string) bool {
-    return false
+    var sb = s as []byte
+    var pb = prefix as []byte
+    if len(pb) > len(sb) {
+        return false
+    }
+    var i = 0
+    for i < len(pb) {
+        if sb[i] != pb[i] {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // hasSuffix reports whether s ends with suffix.
 pub fun hasSuffix(s string, suffix string) bool {
-    return false
+    var sb = s as []byte
+    var xb = suffix as []byte
+    if len(xb) > len(sb) {
+        return false
+    }
+    var offset = len(sb) - len(xb)
+    var i = 0
+    for i < len(xb) {
+        if sb[offset + i] != xb[i] {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // indexOf returns the index of the first occurrence of substr in s,
 // or null if substr is not present.
 pub fun indexOf(s string, substr string) int? {
+    var sb = s as []byte
+    var nb = substr as []byte
+    if len(nb) == 0 {
+        return .some(0)
+    }
+    if len(nb) > len(sb) {
+        return null
+    }
+    var i = 0
+    var limit = len(sb) - len(nb)
+    for i <= limit {
+        var j = 0
+        var match = true
+        for j < len(nb) {
+            if sb[i + j] != nb[j] {
+                match = false
+                break
+            }
+            j = j + 1
+        }
+        if match {
+            return .some(i)
+        }
+        i = i + 1
+    }
     return null
 }
 
 // lastIndexOf returns the index of the last occurrence of substr in s,
 // or null if substr is not present.
 pub fun lastIndexOf(s string, substr string) int? {
+    var sb = s as []byte
+    var nb = substr as []byte
+    if len(nb) == 0 {
+        return .some(len(sb))
+    }
+    if len(nb) > len(sb) {
+        return null
+    }
+    var i = len(sb) - len(nb)
+    for i >= 0 {
+        var j = 0
+        var match = true
+        for j < len(nb) {
+            if sb[i + j] != nb[j] {
+                match = false
+                break
+            }
+            j = j + 1
+        }
+        if match {
+            return .some(i)
+        }
+        i = i - 1
+    }
     return null
 }
 
 // count counts the number of non-overlapping instances of substr in s.
 pub fun count(s string, substr string) int {
-    return 0
+    var sb = s as []byte
+    var nb = substr as []byte
+    if len(nb) == 0 {
+        return len(sb) + 1
+    }
+    var n = 0
+    var pos = 0
+    for pos <= len(sb) - len(nb) {
+        var j = 0
+        var match = true
+        for j < len(nb) {
+            if sb[pos + j] != nb[j] {
+                match = false
+                break
+            }
+            j = j + 1
+        }
+        if match {
+            n = n + 1
+            pos = pos + len(nb)
+        } else {
+            pos = pos + 1
+        }
+    }
+    return n
 }
 
 // split splits s around each instance of sep, returning a slice of substrings.
 pub fun split(s string, sep string) []string {
-    return alloc([]string, 0)
+    return splitN(s, sep, -1)
 }
 
 // splitN splits s around the first n instances of sep.
 // If n < 0, there is no limit on the number of splits.
 pub fun splitN(s string, sep string, n int) []string {
-    return alloc([]string, 0)
+    var result = alloc([]string, 0)
+    var sb = s as []byte
+    var sepb = sep as []byte
+    if len(sepb) == 0 {
+        // Split into individual characters.
+        var i = 0
+        var count = 0
+        for i < len(sb) {
+            if n >= 0 {
+                if count >= n - 1 {
+                    break
+                }
+            }
+            var ch = alloc([]byte, 1)
+            ch[0] = sb[i]
+            result = append(result, ch as string)
+            count = count + 1
+            i = i + 1
+        }
+        if i < len(sb) {
+            result = append(result, sb[i..len(sb)] as string)
+        }
+        return result
+    }
+    var pos = 0
+    var splits = 0
+    for pos <= len(sb) {
+        if n >= 0 {
+            if splits >= n - 1 {
+                break
+            }
+        }
+        // Search for sep starting at pos.
+        var found = false
+        var idx = pos
+        for idx <= len(sb) - len(sepb) {
+            var j = 0
+            var match = true
+            for j < len(sepb) {
+                if sb[idx + j] != sepb[j] {
+                    match = false
+                    break
+                }
+                j = j + 1
+            }
+            if match {
+                found = true
+                break
+            }
+            idx = idx + 1
+        }
+        if found {
+            result = append(result, sb[pos..idx] as string)
+            pos = idx + len(sepb)
+            splits = splits + 1
+        } else {
+            break
+        }
+    }
+    // Append the remaining part.
+    result = append(result, sb[pos..len(sb)] as string)
+    return result
 }
 
 // fields splits s around runs of whitespace characters,
 // returning a slice of substrings with no empty strings.
 pub fun fields(s string) []string {
-    return alloc([]string, 0)
+    var result = alloc([]string, 0)
+    var sb = s as []byte
+    var i = 0
+    for i < len(sb) {
+        // Skip whitespace.
+        for i < len(sb) {
+            if sb[i] != 32 {
+                if sb[i] != 9 {
+                    if sb[i] != 10 {
+                        if sb[i] != 13 {
+                            break
+                        }
+                    }
+                }
+            }
+            i = i + 1
+        }
+        if i >= len(sb) {
+            break
+        }
+        // Collect non-whitespace.
+        var start = i
+        for i < len(sb) {
+            if sb[i] == 32 {
+                break
+            }
+            if sb[i] == 9 {
+                break
+            }
+            if sb[i] == 10 {
+                break
+            }
+            if sb[i] == 13 {
+                break
+            }
+            i = i + 1
+        }
+        result = append(result, sb[start..i] as string)
+    }
+    return result
 }
 
 // join concatenates the elements of parts with sep between each element.
 pub fun join(parts []string, sep string) string {
-    return ""
+    if len(parts) == 0 {
+        return ""
+    }
+    var b = Builder{ buf: alloc([]byte, 0) }
+    var i = 0
+    for i < len(parts) {
+        if i > 0 {
+            b.writeString(sep)
+        }
+        b.writeString(parts[i])
+        i = i + 1
+    }
+    return b.string()
 }
 
 // replace returns a copy of s with all non-overlapping instances of old
 // replaced by new.
 pub fun replace(s string, old string, new string) string {
-    return ""
+    return replaceN(s, old, new, -1)
 }
 
 // replaceN returns a copy of s with the first n non-overlapping instances
 // of old replaced by new. If n < 0, all instances are replaced.
 pub fun replaceN(s string, old string, new string, n int) string {
-    return ""
+    var sb = s as []byte
+    var oldb = old as []byte
+    if len(oldb) == 0 {
+        return s
+    }
+    var b = Builder{ buf: alloc([]byte, 0) }
+    var pos = 0
+    var replacements = 0
+    for pos <= len(sb) {
+        if n >= 0 {
+            if replacements >= n {
+                break
+            }
+        }
+        // Search for old starting at pos.
+        var found = false
+        var idx = pos
+        for idx <= len(sb) - len(oldb) {
+            var j = 0
+            var match = true
+            for j < len(oldb) {
+                if sb[idx + j] != oldb[j] {
+                    match = false
+                    break
+                }
+                j = j + 1
+            }
+            if match {
+                found = true
+                break
+            }
+            idx = idx + 1
+        }
+        if found {
+            // Append text before the match.
+            b.writeString(sb[pos..idx] as string)
+            b.writeString(new)
+            pos = idx + len(oldb)
+            replacements = replacements + 1
+        } else {
+            break
+        }
+    }
+    // Append remaining text.
+    b.writeString(sb[pos..len(sb)] as string)
+    return b.string()
+}
+
+fun isWhitespace(c byte) bool {
+    if c == 32 {
+        return true
+    }
+    if c == 9 {
+        return true
+    }
+    if c == 10 {
+        return true
+    }
+    if c == 13 {
+        return true
+    }
+    return false
 }
 
 // trim returns s with leading and trailing whitespace removed.
 pub fun trim(s string) string {
-    return ""
+    var sb = s as []byte
+    var start = 0
+    for start < len(sb) {
+        if !isWhitespace(sb[start]) {
+            break
+        }
+        start = start + 1
+    }
+    var end = len(sb)
+    for end > start {
+        if !isWhitespace(sb[end - 1]) {
+            break
+        }
+        end = end - 1
+    }
+    return sb[start..end] as string
 }
 
 // trimLeft returns s with leading whitespace removed.
 pub fun trimLeft(s string) string {
-    return ""
+    var sb = s as []byte
+    var start = 0
+    for start < len(sb) {
+        if !isWhitespace(sb[start]) {
+            break
+        }
+        start = start + 1
+    }
+    return sb[start..len(sb)] as string
 }
 
 // trimRight returns s with trailing whitespace removed.
 pub fun trimRight(s string) string {
-    return ""
+    var sb = s as []byte
+    var end = len(sb)
+    for end > 0 {
+        if !isWhitespace(sb[end - 1]) {
+            break
+        }
+        end = end - 1
+    }
+    return sb[0..end] as string
 }
 
 // trimPrefix returns s without the provided leading prefix.
 // If s doesn't start with prefix, s is returned unchanged.
 pub fun trimPrefix(s string, prefix string) string {
-    return ""
+    if hasPrefix(s, prefix) {
+        var sb = s as []byte
+        var pb = prefix as []byte
+        return sb[len(pb)..len(sb)] as string
+    }
+    return s
 }
 
 // trimSuffix returns s without the provided trailing suffix.
 // If s doesn't end with suffix, s is returned unchanged.
 pub fun trimSuffix(s string, suffix string) string {
-    return ""
+    if hasSuffix(s, suffix) {
+        var sb = s as []byte
+        var xb = suffix as []byte
+        return sb[0..len(sb) - len(xb)] as string
+    }
+    return s
 }
 
 // trimChars returns s with all leading and trailing characters
 // contained in cutset removed.
 pub fun trimChars(s string, cutset string) string {
-    return ""
+    var sb = s as []byte
+    var cb = cutset as []byte
+    var start = 0
+    for start < len(sb) {
+        if !charInSet(sb[start], cb) {
+            break
+        }
+        start = start + 1
+    }
+    var end = len(sb)
+    for end > start {
+        if !charInSet(sb[end - 1], cb) {
+            break
+        }
+        end = end - 1
+    }
+    return sb[start..end] as string
 }
 
-// toUpper returns s with all Unicode letters mapped to their upper case.
+fun charInSet(c byte, set []byte) bool {
+    var i = 0
+    for i < len(set) {
+        if set[i] == c {
+            return true
+        }
+        i = i + 1
+    }
+    return false
+}
+
+// toUpper returns s with all ASCII letters mapped to their upper case.
 pub fun toUpper(s string) string {
-    return ""
+    var sb = s as []byte
+    var result = alloc([]byte, len(sb))
+    var i = 0
+    for i < len(sb) {
+        var c = sb[i]
+        if c >= 97 {
+            if c <= 122 {
+                c = c - 32
+            }
+        }
+        result[i] = c
+        i = i + 1
+    }
+    return result as string
 }
 
-// toLower returns s with all Unicode letters mapped to their lower case.
+// toLower returns s with all ASCII letters mapped to their lower case.
 pub fun toLower(s string) string {
-    return ""
+    var sb = s as []byte
+    var result = alloc([]byte, len(sb))
+    var i = 0
+    for i < len(sb) {
+        var c = sb[i]
+        if c >= 65 {
+            if c <= 90 {
+                c = c + 32
+            }
+        }
+        result[i] = c
+        i = i + 1
+    }
+    return result as string
 }
 
 // toTitle returns s with the first letter of each word capitalized.
 pub fun toTitle(s string) string {
-    return ""
+    var sb = s as []byte
+    var result = alloc([]byte, len(sb))
+    var capitalize = true
+    var i = 0
+    for i < len(sb) {
+        var c = sb[i]
+        if isWhitespace(c) {
+            capitalize = true
+            result[i] = c
+        } else {
+            if capitalize {
+                if c >= 97 {
+                    if c <= 122 {
+                        c = c - 32
+                    }
+                }
+                capitalize = false
+            } else {
+                if c >= 65 {
+                    if c <= 90 {
+                        c = c + 32
+                    }
+                }
+            }
+            result[i] = c
+        }
+        i = i + 1
+    }
+    return result as string
 }
 
 // repeat returns a string consisting of count copies of s.
 pub fun repeat(s string, count int) string {
-    return ""
+    if count <= 0 {
+        return ""
+    }
+    var b = Builder{ buf: alloc([]byte, 0) }
+    var i = 0
+    for i < count {
+        b.writeString(s)
+        i = i + 1
+    }
+    return b.string()
 }
 
 // equalFold reports whether s and t are equal under Unicode case-folding.
+// Currently handles ASCII case-folding only.
 pub fun equalFold(a string, b string) bool {
-    return false
+    var ab = a as []byte
+    var bb = b as []byte
+    if len(ab) != len(bb) {
+        return false
+    }
+    var i = 0
+    for i < len(ab) {
+        var ca = ab[i]
+        var cb = bb[i]
+        // Normalize to lower case for comparison.
+        if ca >= 65 {
+            if ca <= 90 {
+                ca = ca + 32
+            }
+        }
+        if cb >= 65 {
+            if cb <= 90 {
+                cb = cb + 32
+            }
+        }
+        if ca != cb {
+            return false
+        }
+        i = i + 1
+    }
+    return true
 }
 
 // startsWith is an alias for hasPrefix.
 pub fun startsWith(s string, prefix string) bool {
-    return false
+    return hasPrefix(s, prefix)
 }
 
 // endsWith is an alias for hasSuffix.
 pub fun endsWith(s string, suffix string) bool {
-    return false
+    return hasSuffix(s, suffix)
 }


### PR DESCRIPTION
## Summary

- Implement 6 stdlib packages that were previously stubs with empty function bodies, filling in real logic following established patterns from `io.run` and `errors.run`
- **strings** (#235): Builder, search/transform/split/join/trim/case-conversion functions (27 functions)
- **bytes** (#236): Buffer implementing `io.Reader`/`io.Writer`, plus search/transform/split/join functions (16 functions)
- **iter** (#237): Iterator interface with 12 private combinator structs (MapIterator, FilterIterator, TakeIterator, etc.) and 6 terminal operations (17 functions + Pair type)
- **slices** (#238): Search, insertion sort, reverse, insert/delete, binary search, chunk, concat (17 functions)
- **maps** (#239): keys, values, clone, equal, equalFunc, deleteFunc, copy, has (8 functions)
- **cmp** (#240): Ordering-based compare/min/max/clamp with Ordered interface and built-in type fallbacks (4 functions filled in, 5 already implemented)

Closes #235 #236 #237 #238 #239 #240

## Test plan

- [ ] Verify all function signatures remain unchanged from the original stubs
- [ ] Review implementations against language patterns in `io.run` and `errors.run`
- [ ] Verify private structs (iter combinators) follow visibility conventions (no `pub`)
- [ ] Once compiler supports stdlib compilation, run stdlib test suite

https://claude.ai/code/session_01YPs3xgXGRMmaKXsM8hrRVa