### PR TITLE
Add stdlib compilation check to CI

### DIFF
--- a/.github/workflows/zig-ci.yml
+++ b/.github/workflows/zig-ci.yml
@@ -154,20 +154,20 @@ jobs:
 
       - name: Check all stdlib packages
         if: steps.changes.outputs.should_run == 'true'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           passed=0
           failed=0
           failed_files=""
 
           while IFS= read -r file; do
-            if output=$(timeout 30 ./zig-out/bin/run check --no-color "$file" 2>&1); then
+            if output=$(timeout 5 ./zig-out/bin/run check --no-color "$file" 2>&1); then
               echo "PASS: $file"
               passed=$((passed + 1))
             else
               exit_code=$?
               if [ "$exit_code" -eq 124 ]; then
-                echo "TIMEOUT: $file (killed after 30s)"
+                echo "TIMEOUT: $file (killed after 5s)"
               else
                 echo "FAIL: $file"
               fi
@@ -192,14 +192,14 @@ jobs:
 
       - name: Summary
         if: always() && steps.changes.outputs.should_run == 'true'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           echo "## Stdlib Compilation Check" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| File | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
           while IFS= read -r file; do
-            if output=$(timeout 30 ./zig-out/bin/run check --no-color "$file" 2>&1); then
+            if output=$(timeout 5 ./zig-out/bin/run check --no-color "$file" 2>&1); then
               echo "| \`$file\` | :white_check_mark: Pass |" >> "$GITHUB_STEP_SUMMARY"
             else
               exit_code=$?


### PR DESCRIPTION
## Summary

- Adds a new `stdlib-check` job to the Zig CI workflow that runs `run check` on every non-test `.run` file in `stdlib/`
- Dynamically discovers all stdlib packages (~91 files) — new packages are automatically included without workflow edits
- Reports individual PASS/FAIL per file in CI logs, with a summary table in GitHub Step Summary
- Catches syntax errors like missing `type` keyword in struct declarations (e.g., `pub File struct {` instead of `pub type File struct {`)

## Test plan

- [ ] Verify the `stdlib-check` job appears in the CI dashboard alongside existing jobs
- [ ] Confirm the job builds the compiler, then checks each stdlib `.run` file
- [ ] Verify files with syntax errors (e.g., `stdlib/archive/zip/zip.run`) are reported as FAIL
- [ ] Verify the GitHub Step Summary renders a markdown table with pass/fail status per file
- [x] Confirm the job fails overall when any file fails compilation

https://claude.ai/code/session_01JyTjS4dKSpffnvyTJLJKd3