### PR TITLE
Add core testing assertions to stdlib/testing (Fixes #245)

### DIFF
--- a/stdlib/testing/testing.run
+++ b/stdlib/testing/testing.run
@@ -81,6 +81,38 @@ pub fun (t &T) run(name string, body fun(t &T)) {
 pub fun (t &T) expect(got any, op Operator) {
 }
 
+// assert fails the test if cond is false.
+pub fun (t &T) assert(cond bool) {
+    if !cond {
+        t.fail()
+    }
+}
+
+// assert_eq fails the test if got != want.
+pub fun (t &T) assert_eq(got any, want any) {
+    t.expect(got, t.eq(want))
+}
+
+// assert_ne fails the test if got == want.
+pub fun (t &T) assert_ne(got any, want any) {
+    t.expect(got, t.ne(want))
+}
+
+// assert_err fails the test if the error union does not currently hold an error.
+pub fun (t &T) assert_err(value any) {
+    t.expect(value, t.isErr())
+}
+
+// assertEqual is a camelCase alias for assert_eq.
+pub fun (t &T) assertEqual(got any, want any) {
+    t.assert_eq(got, want)
+}
+
+// assertNotEqual is a camelCase alias for assert_ne.
+pub fun (t &T) assertNotEqual(got any, want any) {
+    t.assert_ne(got, want)
+}
+
 // parallel marks this test as safe to run in parallel with other
 // parallel-marked tests. Must be called before any test logic.
 pub fun (t &T) parallel() {


### PR DESCRIPTION
### Motivation
- Provide the assertion API surface expected by stdlib tests and requested in issue `#245`, so tests can use `t.assert`, `t.assert_eq`, `t.assert_ne`, and `t.assert_err` (plus camelCase aliases). 

### Description
- Added new `T` methods in `stdlib/testing/testing.run`: `assert(cond bool)`, `assert_eq(got any, want any)`, `assert_ne(got any, want any)`, and `assert_err(value any)` that delegate to the existing `t.fail()`/`t.expect`/operator helpers.
- Added camelCase compatibility aliases `assertEqual(got, want)` and `assertNotEqual(got, want)` to match existing test callsites.
- Implementations are minimal and use `t.fail()` for boolean asserts and `t.expect` with `t.eq`/`t.ne`/`t.isErr` for equality and error checks.

### Testing
- Attempted to run the test suite with `zig build test`, but the command could not be executed in this environment because `zig` is not installed (`/bin/bash: line 1: zig: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9a763320832cad818a7cbb894182)