### PR TITLE
Implement stdlib simd, numa, asm packages

### DIFF
--- a/stdlib/asm/asm.run
+++ b/stdlib/asm/asm.run
@@ -8,66 +8,110 @@ pub type Arch = .x86_64
 
 // arch returns the current target architecture.
 pub fun arch() Arch {
+    if isX8664 {
+        return .x86_64
+    }
+    if isAarch64 {
+        return .aarch64
+    }
+    if isRiscv64 {
+        return .riscv64
+    }
+    if isWasm32 {
+        return .wasm32
+    }
     return .x86_64
 }
 
 // Platform detection constants (compile-time).
-pub let isX8664 = false
-pub let isAarch64 = false
-pub let isRiscv64 = false
-pub let isWasm32 = false
+pub let isX8664 = __builtin_is_x86_64()
+pub let isAarch64 = __builtin_is_aarch64()
+pub let isRiscv64 = __builtin_is_riscv64()
+pub let isWasm32 = __builtin_is_wasm32()
 
 // hasAvx reports whether the CPU supports AVX instructions.
 pub fun hasAvx() bool {
+    if isX8664 {
+        return __builtin_cpu_has_feature("avx")
+    }
     return false
 }
 
 // hasAvx2 reports whether the CPU supports AVX2 instructions.
 pub fun hasAvx2() bool {
+    if isX8664 {
+        return __builtin_cpu_has_feature("avx2")
+    }
     return false
 }
 
 // hasAvx512 reports whether the CPU supports AVX-512 instructions.
 pub fun hasAvx512() bool {
+    if isX8664 {
+        return __builtin_cpu_has_feature("avx512f")
+    }
     return false
 }
 
 // hasSse42 reports whether the CPU supports SSE 4.2 instructions.
 pub fun hasSse42() bool {
+    if isX8664 {
+        return __builtin_cpu_has_feature("sse4.2")
+    }
     return false
 }
 
 // hasNeon reports whether the CPU supports ARM NEON instructions.
 pub fun hasNeon() bool {
+    if isAarch64 {
+        return __builtin_cpu_has_feature("neon")
+    }
     return false
 }
 
 // hasSve reports whether the CPU supports ARM SVE instructions.
 pub fun hasSve() bool {
+    if isAarch64 {
+        return __builtin_cpu_has_feature("sve")
+    }
     return false
 }
 
 // fence issues a full memory fence (sequential consistency barrier).
 pub fun fence() {
+    __builtin_memory_fence()
 }
 
 // loadFence issues a load-acquire memory fence.
 pub fun loadFence() {
+    __builtin_load_fence()
 }
 
 // storeFence issues a store-release memory fence.
 pub fun storeFence() {
+    __builtin_store_fence()
 }
 
 // prefetch issues a prefetch hint for the given memory address.
 pub fun prefetch(addr &byte) {
+    __builtin_prefetch(addr)
 }
 
 // cacheLineSize returns the L1 data cache line size in bytes.
 pub fun cacheLineSize() int {
+    if isX8664 {
+        return 64
+    }
+    if isAarch64 {
+        return 64
+    }
+    if isRiscv64 {
+        return 64
+    }
     return 64
 }
 
 // flushCacheLine flushes the cache line containing the given address.
 pub fun flushCacheLine(addr &byte) {
+    __builtin_cache_line_flush(addr)
 }

--- a/stdlib/numa/numa.run
+++ b/stdlib/numa/numa.run
@@ -22,73 +22,140 @@ pub Topology struct {
 
 // available reports whether the system has more than one NUMA node.
 pub fun available() bool {
-    return false
+    return nodeCount() > 1
 }
 
 // nodeCount returns the number of NUMA nodes (>= 1).
 pub fun nodeCount() int {
-    return 0
+    var count = __builtin_numa_node_count()
+    if count < 1 {
+        return 1
+    }
+    return count
 }
 
 // currentNode returns the NUMA node the calling thread is running on.
 pub fun currentNode() int {
-    return 0
+    return __builtin_numa_current_node()
 }
 
 // preferredNode returns the preferred NUMA node of the current
 // green thread, or -1 if no preference is set.
 pub fun preferredNode() int {
-    return -1
+    return __builtin_numa_preferred_node()
 }
 
 // cpuCount returns the number of CPUs on the given NUMA node.
 pub fun cpuCount(node int) int {
-    return 0
+    if node < 0 {
+        return 0
+    }
+    if node >= nodeCount() {
+        return 0
+    }
+    return __builtin_numa_cpu_count(node)
 }
 
 // distance returns the relative distance between two NUMA nodes.
 // A distance of 10 indicates local access; higher values indicate
 // increasing latency.
 pub fun distance(nodeA int, nodeB int) int {
-    return 0
+    if nodeA == nodeB {
+        return 10
+    }
+    var count = nodeCount()
+    if nodeA < 0 {
+        return -1
+    }
+    if nodeA >= count {
+        return -1
+    }
+    if nodeB < 0 {
+        return -1
+    }
+    if nodeB >= count {
+        return -1
+    }
+    return __builtin_numa_distance(nodeA, nodeB)
 }
 
 // memoryOnNode returns the total memory in bytes on the given node.
 pub fun memoryOnNode(node int) int {
-    return 0
+    if node < 0 {
+        return 0
+    }
+    if node >= nodeCount() {
+        return 0
+    }
+    return __builtin_numa_memory_on_node(node)
 }
 
 // localAlloc allocates size bytes on the current thread's NUMA node.
 pub fun localAlloc(size int) &byte {
-    return null
+    if size <= 0 {
+        return null
+    }
+    return __builtin_numa_local_alloc(size)
 }
 
 // nodeAlloc allocates size bytes on the specified NUMA node.
 pub fun nodeAlloc(node int, size int) &byte {
-    return null
+    if size <= 0 {
+        return null
+    }
+    if node < 0 {
+        return null
+    }
+    if node >= nodeCount() {
+        return null
+    }
+    return __builtin_numa_node_alloc(node, size)
 }
 
 // interleaveAlloc allocates size bytes interleaved round-robin
 // across all NUMA nodes.
 pub fun interleaveAlloc(size int) &byte {
-    return null
+    if size <= 0 {
+        return null
+    }
+    return __builtin_numa_interleave_alloc(size)
 }
 
 // free releases memory previously allocated by localAlloc,
 // nodeAlloc, or interleaveAlloc.
 pub fun free(ptr &byte, size int) {
+    if ptr == null {
+        return
+    }
+    if size <= 0 {
+        return
+    }
+    __builtin_numa_free(ptr, size)
 }
 
 // bindThread binds the calling OS thread to CPUs on the given
 // NUMA node. Returns 0 on success, -1 on failure.
 pub fun bindThread(node int) int {
-    return 0
+    if node < 0 {
+        return -1
+    }
+    if node >= nodeCount() {
+        return -1
+    }
+    return __builtin_numa_bind_thread(node)
 }
 
 // bindGreenThread sets the preferred NUMA node for the current
 // green thread. The scheduler will prefer running the thread on
 // a processor assigned to that node.
 pub fun bindGreenThread(node int) {
+    if node < 0 {
+        return
+    }
+    if node >= nodeCount() {
+        return
+    }
+    __builtin_numa_bind_green_thread(node)
 }
 
 // setMemoryPolicy sets the memory placement policy for the
@@ -96,5 +163,27 @@ pub fun bindGreenThread(node int) {
 // node is used by policyBind and policyPreferred.
 // Returns 0 on success, -1 on failure.
 pub fun setMemoryPolicy(policy int, node int) int {
-    return 0
+    if policy < policyLocal {
+        return -1
+    }
+    if policy > policyPreferred {
+        return -1
+    }
+    if policy == policyBind {
+        if node < 0 {
+            return -1
+        }
+        if node >= nodeCount() {
+            return -1
+        }
+    }
+    if policy == policyPreferred {
+        if node < 0 {
+            return -1
+        }
+        if node >= nodeCount() {
+            return -1
+        }
+    }
+    return __builtin_numa_set_memory_policy(policy, node)
 }

--- a/stdlib/simd/simd.run
+++ b/stdlib/simd/simd.run
@@ -7,103 +7,156 @@ package simd
 
 // hadd returns the horizontal sum (reduction) of all lanes.
 pub fun hadd(v v4f32) f32 {
-    return 0.0
+    var s = v[0] + v[1] + v[2] + v[3]
+    return s
 }
 
 // dot returns the dot product of two vectors.
 pub fun dot(a v4f32, b v4f32) f32 {
-    return 0.0
+    var prod = a * b
+    return hadd(prod)
 }
 
 // shuffle permutes vector lanes using compile-time literal indices.
 pub fun shuffle(v v4f32, i0 int, i1 int, i2 int, i3 int) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return v4f32{ v[i0], v[i1], v[i2], v[i3] }
 }
 
 // min returns the element-wise minimum of two vectors.
 pub fun min(a v4f32, b v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var r = v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var i = 0
+    for i < 4 {
+        if a[i] < b[i] {
+            r[i] = a[i]
+        } else {
+            r[i] = b[i]
+        }
+        i = i + 1
+    }
+    return r
 }
 
 // max returns the element-wise maximum of two vectors.
 pub fun max(a v4f32, b v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var r = v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var i = 0
+    for i < 4 {
+        if a[i] > b[i] {
+            r[i] = a[i]
+        } else {
+            r[i] = b[i]
+        }
+        i = i + 1
+    }
+    return r
 }
 
 // select blends two vectors using a mask: mask[i] ? a[i] : b[i].
 pub fun select(mask v4bool, a v4f32, b v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var r = v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var i = 0
+    for i < 4 {
+        if mask[i] {
+            r[i] = a[i]
+        } else {
+            r[i] = b[i]
+        }
+        i = i + 1
+    }
+    return r
 }
 
 // load performs an aligned load from a pointer to a vector.
 pub fun load(ptr @v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return __builtin_simd_load_aligned(ptr)
 }
 
 // loadUnaligned performs an unaligned load from a pointer to a vector.
 pub fun loadUnaligned(ptr @v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return __builtin_simd_load_unaligned(ptr)
 }
 
 // store performs an aligned store of a vector through a mutable pointer.
 pub fun store(ptr &v4f32, v v4f32) {
+    __builtin_simd_store_aligned(ptr, v)
 }
 
 // width returns the compiled SIMD fast-path width in bits
 // (256 for AVX, 128 for SSE/NEON, 0 for scalar fallback).
 pub fun width() int {
+    if __builtin_has_avx() {
+        return 256
+    }
+    if __builtin_has_sse2() {
+        return 128
+    }
+    if __builtin_has_neon() {
+        return 128
+    }
     return 0
 }
 
 // sqrt returns the element-wise square root. Float vectors only.
 pub fun sqrt(v v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return __builtin_simd_sqrt(v)
 }
 
 // abs returns the element-wise absolute value. Float vectors only.
 pub fun abs(v v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var r = v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var i = 0
+    for i < 4 {
+        if v[i] < 0.0 {
+            r[i] = -v[i]
+        } else {
+            r[i] = v[i]
+        }
+        i = i + 1
+    }
+    return r
 }
 
 // floor returns the element-wise floor. Float vectors only.
 pub fun floor(v v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return __builtin_simd_floor(v)
 }
 
 // ceil returns the element-wise ceiling. Float vectors only.
 pub fun ceil(v v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return __builtin_simd_ceil(v)
 }
 
 // round returns the element-wise round to nearest. Float vectors only.
 pub fun round(v v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return __builtin_simd_round(v)
 }
 
 // fma returns fused multiply-add: a*b + c, element-wise. Float vectors only.
 pub fun fma(a v4f32, b v4f32, c v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return a * b + c
 }
 
 // clamp returns element-wise clamping to the range [lo, hi].
 pub fun clamp(v v4f32, lo v4f32, hi v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return min(max(v, lo), hi)
 }
 
 // broadcast fills all lanes of vector type T with the given scalar value.
 // Usage: simd.broadcast(v4f32, 1.0)
 pub fun broadcast(v v4f32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    var val = v[0]
+    return v4f32{ val, val, val, val }
 }
 
 // i32ToF32 converts an integer vector to a float vector.
 // Works with v4i32 -> v4f32 and v8i32 -> v8f32.
 pub fun i32ToF32(v v4i32) v4f32 {
-    return v4f32{ 0.0, 0.0, 0.0, 0.0 }
+    return __builtin_simd_i32_to_f32(v)
 }
 
 // f32ToI32 converts a float vector to an integer vector.
 // Works with v4f32 -> v4i32 and v8f32 -> v8i32.
 pub fun f32ToI32(v v4f32) v4i32 {
-    return v4i32{ 0, 0, 0, 0 }
+    return __builtin_simd_f32_to_i32(v)
 }


### PR DESCRIPTION
## Summary

- **simd**: Implement all SIMD vector operation bodies -- horizontal add, dot product, shuffle, element-wise min/max/abs/clamp, select/blend, FMA, broadcast, type conversions, and intrinsic-backed sqrt/floor/ceil/round/load/store
- **numa**: Implement NUMA topology queries, allocation (local/node/interleave), thread binding, and memory policy with proper input validation and `__builtin_numa_*` intrinsics
- **asm**: Implement platform detection via `__builtin_is_*` compile-time constants, CPU feature detection via `__builtin_cpu_has_feature`, memory fences, prefetch, and cache line operations

Fixes #289

## Test plan

- [x] `zig build run -- check stdlib/simd/simd.run` passes (448 nodes)
- [x] `zig build run -- check stdlib/numa/numa.run` passes (397 nodes)
- [x] `zig build run -- check stdlib/asm/asm.run` passes (187 nodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)