### PR TITLE
Fix fd close race condition in xev bridge and io_uring

### DIFF
--- a/src/runtime/run_xev_bridge.zig
+++ b/src/runtime/run_xev_bridge.zig
@@ -130,12 +130,18 @@ export fn run_xev_close_fd(fd: c_int) void {
 
     // Drain the loop so cancel operations retire before the fd number can be
     // reused by a later test. kqueue may need more than one no-wait pass when
-    // cancellation completions enqueue follow-up work.
+    // cancellation completions enqueue follow-up work. We must also wait for
+    // the cancel completions themselves to retire — overwriting their storage
+    // while a CQE is still pending in the io_uring ring would later cause
+    // libxev to invoke a completion whose op has been reset to .noop, hitting
+    // an unreachable in Completion.invoke().
     var drain_count: u8 = 0;
-    while (drain_count < 32) : (drain_count += 1) {
+    while (drain_count < 64) : (drain_count += 1) {
         const read_active = slot.read_completion.state() == .active;
         const write_active = slot.write_completion.state() == .active;
-        if (!read_active and !write_active) break;
+        const read_cancel_active = slot.read_cancel.state() == .active;
+        const write_cancel_active = slot.write_cancel.state() == .active;
+        if (!read_active and !write_active and !read_cancel_active and !write_cancel_active) break;
         loop.run(.no_wait) catch {};
     }
 
@@ -148,10 +154,16 @@ export fn run_xev_close_fd(fd: c_int) void {
     }
 
     const next_generation = slot.generation;
-    slot.read_completion = .{};
-    slot.write_completion = .{};
-    slot.read_cancel = .{};
-    slot.write_cancel = .{};
+    // Only reset completion storage that has retired. If a cancel completion
+    // is somehow still active (e.g., the kernel hasn't reaped it yet after
+    // exhausting our drain budget), leave it alone so its eventual CQE finds
+    // a valid op rather than .noop. The slot is marked inactive, so the
+    // pollCallback/writePollCallback guards (active/generation checks) will
+    // disarm safely.
+    if (slot.read_completion.state() != .active) slot.read_completion = .{};
+    if (slot.write_completion.state() != .active) slot.write_completion = .{};
+    if (slot.read_cancel.state() != .active) slot.read_cancel = .{};
+    if (slot.write_cancel.state() != .active) slot.write_cancel = .{};
     slot.read_ctx = .{};
     slot.write_ctx = .{};
     slot.read_armed = false;

--- a/zig-pkg/libxev-0.0.0-86vtcwIRFACVrx54GaHsMFFlyC4dTi0tcVh10V7btRUc/src/backend/io_uring.zig
+++ b/zig-pkg/libxev-0.0.0-86vtcwIRFACVrx54GaHsMFFlyC4dTi0tcVh10V7btRUc/src/backend/io_uring.zig
@@ -193,6 +193,11 @@ pub const Loop = struct {
             for (cqes[0..count]) |cqe| {
                 const c = @as(?*Completion, @ptrFromInt(@as(usize, @intCast(cqe.user_data)))) orelse continue;
                 self.active -= 1;
+                // If the user reset this completion before its CQE arrived,
+                // its op is now .noop and invoke() would hit unreachable.
+                // Skip processing and leave the completion in its (already
+                // dead) reset state.
+                if (c.flags.state != .active) continue;
                 c.flags.state = .dead;
                 switch (c.invoke(self, cqe.res)) {
                     .disarm => {},
@@ -692,6 +697,7 @@ pub const Completion = struct {
 
             .poll => .{
                 .poll = if (res >= 0) {} else switch (@as(posix.E, @enumFromInt(-res))) {
+                    .CANCELED => error.Canceled,
                     else => |errno| posix.unexpectedErrno(errno),
                 },
             },


### PR DESCRIPTION
## Summary
This PR fixes a critical race condition in the xev bridge's file descriptor close handling where completion operations could be reset while their CQEs were still pending in the io_uring ring, causing libxev to invoke completions with invalid `.noop` ops.

## Key Changes

- **Extended drain loop in `run_xev_close_fd`**: Increased drain count from 32 to 64 iterations to allow more time for cancel completions to retire before resetting completion storage.

- **Added cancel completion state checks**: Modified the drain loop to also check `read_cancel` and `write_cancel` completion states, not just the main read/write completions, ensuring all pending operations are fully retired.

- **Conditional completion reset**: Changed from unconditionally resetting all completion storage to only resetting completions that have actually retired (state != .active). This prevents overwriting storage while CQEs are still pending.

- **Added io_uring CQE safety check**: Added a guard in the io_uring backend's CQE processing loop to skip completions that have been reset to `.noop` state, preventing unreachable code paths in `Completion.invoke()`.

- **Added CANCELED error handling**: Added explicit handling for `CANCELED` errno in poll operation results, properly converting kernel cancellation signals to error states.

## Implementation Details

The root cause was that cancel completions could still have pending CQEs in the io_uring ring after the drain loop exhausted its budget. When the slot was then reused for a new fd, the old completion storage would be overwritten, causing the eventual CQE to reference invalid operation data. The fix uses a defensive approach: drain more aggressively, check all completion types, conditionally reset only retired completions, and add a safety check in the backend to handle any remaining edge cases gracefully.

https://claude.ai/code/session_01CSYWLMHrkzjcwCbEwHtCLT