### PR TITLE
Fix xev async wakeup rearm for poller (#395)

### DIFF
--- a/src/runtime/run_xev.c
+++ b/src/runtime/run_xev.c
@@ -74,6 +74,7 @@ void run_poller_init(void) {
         abort();
     }
     run_xev_async_init();
+    run_xev_async_wait();
 #endif
 }
 

--- a/src/runtime/run_xev_bridge.zig
+++ b/src/runtime/run_xev_bridge.zig
@@ -373,12 +373,6 @@ export fn run_xev_tick_blocking(timeout_ms: i64) c_int {
         return run_xev_tick();
     }
 
-    // Re-register async wait so notify wakes us
-    if (async_initialized) {
-        async_completion = .{};
-        async_wakeup.wait(&loop, &async_completion, void, null, &asyncNoop);
-    }
-
     if (timeout_ms > 0) {
         var timer = Timer.init() catch return -1;
         defer timer.deinit();
@@ -417,6 +411,7 @@ export fn run_xev_async_notify() c_int {
 /// Register a wait on the async notification.
 export fn run_xev_async_wait() void {
     if (!async_initialized) return;
+    if (async_completion.state() == .active) return;
     async_completion = .{};
     async_wakeup.wait(&loop, &async_completion, void, null, &asyncNoop);
 }
@@ -427,7 +422,7 @@ fn asyncNoop(
     _: *Completion,
     _: Async.WaitError!void,
 ) CallbackAction {
-    return .disarm;
+    return .rearm;
 }
 
 /// Returns true if there are registered fds.


### PR DESCRIPTION
### Motivation
- Address race/missed-wakeup behavior reported in issue #395 by ensuring the libxev async wake path stays armed for the scheduler's poller. 
- Cross-thread scheduler wakeups must remain registered while the event loop blocks to avoid lost notifications. 
- Making the async wait idempotent reduces repeated re-registration and the related timing window.

### Description
- In `src/runtime/run_xev.c` call `run_xev_async_wait()` from `run_poller_init()` so the async wake wait is armed when the poller starts. 
- In `src/runtime/run_xev_bridge.zig` remove per-call async re-registration from `run_xev_tick_blocking()` to avoid resetting the completion on every blocking tick. 
- Make `run_xev_async_wait()` idempotent by checking `async_completion.state()` and returning early if already active. 
- Change the async callback `asyncNoop` to return `.rearm` so the async wait stays armed across blocking ticks instead of disarming after a single notification. 

### Testing
- Attempted to run the runtime poller tests via `zig build test-runtime -Dtest-filter=poller`, but the command failed because `zig` is not installed in the environment (`zig: command not found`). 
- Attempted `make test-runtime` which invokes `zig` and likewise failed with `zig: No such file or directory`, so automated runtime tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f126cbf95c832cafe7e6341ed8e03d)