### PR TITLE
Support field lvalues and const-ref access checks

### DIFF
--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,7 @@
+# Conventions
+
+- Zig 0.16 `ArrayList`: use `.empty`, pass allocator to methods (`append(allocator, item)`, `deinit(allocator)`).
+- Zig stdio: use `std.fs.File.stdout()` / `.stderr()` with `.deprecatedWriter()`.
+- Token tags use `kw_` prefix. AST tags use `_stmt`, `_decl`, `_literal`, and `type_` for type-related nodes.
+- Add or update the nearest behavior test for compiler/runtime changes: inline Zig tests, e2e `.run` cases, runtime `src/runtime/tests/test_*.c`, stdlib `*_test.run`.
+- Preserve unrelated dirty work; current sessions may have generated local metadata like `.serena/project.yml`.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,7 @@
+# Core
+
+- Run compiler workspace. Main pipeline: `.run` source -> lexer -> parser -> naming -> resolve -> typecheck -> lower IR -> C codegen -> `zig cc`.
+- Primary compiler code under `src/`; runtime C under `src/runtime/`; stdlib packages under `stdlib/`; e2e `.run` cases under `tests/e2e/cases/`; docs site under `website/`.
+- Start task context from `CLAUDE.md` and `AGENTS.md`; keep them synchronized when contributor commands/process change.
+- Long-term self-hosting tracked by GitHub issue #188: Zig compiler is stage0; Run compiler rewrite must eventually stage0->stage1->stage2 with stable output/fixpoint.
+- Read `mem:tech_stack` for toolchain details, `mem:conventions` for local style, `mem:suggested_commands` for common commands, and `mem:task_completion` before final verification.

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,11 @@
+# Suggested Commands
+
+- `zig build` builds the compiler.
+- `zig build test` runs Zig unit tests.
+- `zig build test-e2e` runs end-to-end compiler cases.
+- `zig build run -- <command> <file.run>` runs compiler commands: `check`, `run`, `build`, `fmt`, `tokens`, `ast`.
+- `make test-runtime` runs the runtime C suite.
+- Website: `cd website && bun run dev`; production: `cd website && bun run build`.
+- Tree-sitter: `cd editors/tree-sitter-run && bun run test`.
+- VS Code extension: `cd editors/vscode && bun run compile`.
+- Prefer `rg` / `rg --files` for search.

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,7 @@
+# Task Completion
+
+- For compiler changes, run the focused test first, then broaden based on risk: commonly `zig build test`, `zig build test-e2e`, and/or `zig build`.
+- For runtime C changes, run `make test-runtime`; on Linux sanitizer parity is `zig build test -Dsanitize=true`.
+- Format Zig with `zig fmt` on touched Zig files before final verification.
+- Website changes need `cd website && bun run build`; editor changes need their package-specific bun command.
+- Before claiming success, report the exact commands run and whether they exited cleanly; do not infer broad pass status from a narrow check.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,7 @@
+# Tech Stack
+
+- Compiler implementation language: Zig, currently using Zig 0.16 conventions.
+- Runtime: C in `src/runtime/`, built/tested through repo build/make targets and expected to stay clang-format clean.
+- Backend emits C, then uses `zig cc` for native binary compilation.
+- Docs site: Astro/Starlight/Tailwind/React in `website/`; use `bun`, not npm/yarn/pnpm.
+- Editor tooling: VS Code extension and tree-sitter packages under `editors/`, also using bun where applicable.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,22 +3,27 @@ project_name: "runlang"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   haxe                java                julia               kotlin              lua
-#   markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -66,54 +71,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project based on the project name or path.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
-#       for example by saying that the information retrieved from a memory file is no longer correct
-#       or no longer relevant for the project.
-#  * `edit_memory`: Replaces content matching a regular expression in a memory.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_file`: Finds files in the given relative paths
-#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
-#  * `find_symbol`: Performs a global (or local) search using the language server backend.
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
-#       for clients that do not read the initial instructions when the MCP server is connected.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
-#       is relevant to the current task. You can infer whether the information
-#       is relevant from the memory file name.
-#       You should not read the same memory file multiple times in the same conversation.
-#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
-#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
-#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
-#       For JB, we use a separate tool.
-#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
-#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
-#  * `safe_delete_symbol`:
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
-#       The memory name should be meaningful.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -124,11 +92,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -152,3 +123,19 @@ read_only_memory_patterns: []
 # Extends the list from the global configuration, merging the two lists.
 # Example: ["_archive/.*", "_episodes/.*"]
 ignored_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/src/lower.zig
+++ b/src/lower.zig
@@ -1329,17 +1329,33 @@ const LoweringContext = struct {
         self.current_block = func.getBlock(after_bb);
     }
 
-    /// Resolve a struct field by name. Returns its type id, or null.
-    fn structFieldType(self: *const LoweringContext, struct_type: TypeId, field_name: []const u8) ?TypeId {
+    const StructFieldLayout = struct {
+        type_id: TypeId,
+        offset: u32,
+    };
+
+    /// Resolve a struct field by name. Returns its type id and byte offset, or null.
+    fn structFieldLayout(self: *const LoweringContext, struct_type: TypeId, field_name: []const u8) ?StructFieldLayout {
         switch (self.type_pool.get(struct_type)) {
             .struct_type => |st| {
+                var offset: u32 = 0;
                 for (st.fields) |f| {
-                    if (std.mem.eql(u8, f.name, field_name)) return f.type_id;
+                    const field_align = @max(@as(u32, 1), self.alignOfTypeId(f.type_id));
+                    offset = std.mem.alignForward(u32, offset, field_align);
+                    if (std.mem.eql(u8, f.name, field_name)) {
+                        return .{ .type_id = f.type_id, .offset = offset };
+                    }
+                    offset += self.sizeOfTypeId(f.type_id);
                 }
             },
             else => {},
         }
         return null;
+    }
+
+    /// Resolve a struct field by name. Returns its type id, or null.
+    fn structFieldType(self: *const LoweringContext, struct_type: TypeId, field_name: []const u8) ?TypeId {
+        return if (self.structFieldLayout(struct_type, field_name)) |layout| layout.type_id else null;
     }
 
     fn isStructType(self: *const LoweringContext, type_id: TypeId) bool {
@@ -1419,6 +1435,68 @@ const LoweringContext = struct {
         return ir.null_ref;
     }
 
+    const FieldAddress = struct {
+        ptr: ir.Ref,
+        field_type: TypeId,
+    };
+
+    /// Lower `base.field` as an lvalue and return a pointer to the field's storage.
+    fn lowerFieldAddress(self: *LoweringContext, node_idx: NodeIndex) LowerError!?FieldAddress {
+        const node = self.tree.nodes.items[node_idx];
+        const base_idx = node.data.lhs;
+        const field_name = self.tokenSlice(node.main_token + 1);
+        const base_type = self.typeOfNode(base_idx);
+
+        if (self.isStructType(base_type)) {
+            const layout = self.structFieldLayout(base_type, field_name) orelse {
+                try self.unsupported(node_idx, "this field access");
+                return null;
+            };
+            const base = self.tree.nodes.items[base_idx];
+            const base_ptr = switch (base.tag) {
+                .ident => blk: {
+                    const name = self.tokenSlice(base.main_token);
+                    const local_idx = self.lookupLocalIdx(name) orelse {
+                        try self.unsupported(node_idx, "field access on this expression");
+                        return null;
+                    };
+                    const ptr = self.allocRef();
+                    try self.emit(ir.makeInst(.local_addr, ptr, local_idx, 0));
+                    break :blk ptr;
+                },
+                .field_access => blk: {
+                    const addr = (try self.lowerFieldAddress(base_idx)) orelse return null;
+                    break :blk addr.ptr;
+                },
+                else => {
+                    try self.unsupported(node_idx, "field access on this expression");
+                    return null;
+                },
+            };
+            const field_ptr = self.allocRef();
+            try self.emit(ir.makeInst(.field_ptr, field_ptr, base_ptr, layout.offset));
+            return .{ .ptr = field_ptr, .field_type = layout.type_id };
+        }
+
+        if (self.type_pool.unwrapPointer(base_type)) |pointee| {
+            if (self.isStructType(pointee)) {
+                const layout = self.structFieldLayout(pointee, field_name) orelse {
+                    try self.unsupported(node_idx, "this field access");
+                    return null;
+                };
+                const ref_val = try self.lowerExpr(base_idx);
+                const base_ptr = self.allocRef();
+                try self.emit(ir.makeInst(.gen_ref_deref, base_ptr, ref_val, 0));
+                const field_ptr = self.allocRef();
+                try self.emit(ir.makeInst(.field_ptr, field_ptr, base_ptr, layout.offset));
+                return .{ .ptr = field_ptr, .field_type = layout.type_id };
+            }
+        }
+
+        try self.unsupported(node_idx, "field access on this expression");
+        return null;
+    }
+
     /// `base.field = value` for struct locals and pointers-to-struct.
     fn lowerFieldAssign(self: *LoweringContext, lhs_idx: NodeIndex, val_ref: ir.Ref) LowerError!void {
         const lhs = self.tree.nodes.items[lhs_idx];
@@ -1440,7 +1518,10 @@ const LoweringContext = struct {
                     return;
                 }
             }
-            return self.unsupported(lhs_idx, "assignment to a field of this expression");
+            const addr = (try self.lowerFieldAddress(lhs_idx)) orelse return;
+            const type_idx = try self.module.addValueTypeName(self.allocator, self.cTypeForTypeId(addr.field_type));
+            try self.emit(ir.makeInst(.ptr_store_value, val_ref, addr.ptr, type_idx));
+            return;
         }
 
         if (self.type_pool.unwrapPointer(base_type)) |pointee| {
@@ -1518,6 +1599,16 @@ const LoweringContext = struct {
             .ptr, .const_ptr => blk: {
                 if (base_is_ptr) {
                     break :blk try self.lowerExpr(base_idx);
+                }
+                const base = self.tree.nodes.items[base_idx];
+                if (base.tag == .field_access) {
+                    const addr = (try self.lowerFieldAddress(base_idx)) orelse {
+                        try self.unsupported(call_idx, "method call on this expression");
+                        return ir.null_ref;
+                    };
+                    const ref = self.allocRef();
+                    try self.emit(ir.makeInst(.gen_ref_stack, ref, addr.ptr, 0));
+                    break :blk ref;
                 }
                 // Auto address-of: methods on a local take its storage.
                 const local_idx = (try self.lowerStructBaseToLocal(base_idx, mi.struct_type)) orelse {
@@ -2898,6 +2989,15 @@ const LoweringContext = struct {
                         try self.emit(ir.makeInst(.gen_ref_stack, ref_result, local_ptr, 0));
                         return ref_result;
                     }
+                }
+                if (operand_node != null_node and self.tree.nodes.items[operand_node].tag == .field_access) {
+                    const addr = (try self.lowerFieldAddress(operand_node)) orelse {
+                        try self.unsupported(node_idx, "taking the address of this field");
+                        return ir.null_ref;
+                    };
+                    const ref_result = self.allocRef();
+                    try self.emit(ir.makeInst(.gen_ref_stack, ref_result, addr.ptr, 0));
+                    return ref_result;
                 }
 
                 const ptr_ref = try self.lowerExpr(operand_node);

--- a/src/typecheck.zig
+++ b/src/typecheck.zig
@@ -1383,7 +1383,7 @@ const TypeChecker = struct {
                 obj_type_raw = self.symbols.getSymbol(sym_id).type_id;
             }
         } else if (self.nodeTag(obj_node) == .field_access) {
-            // Nested field access: check recursively
+            try self.checkConstPtrFieldAssign(obj_node);
             obj_type_raw = try self.inferExpr(obj_node);
         } else if (self.nodeTag(obj_node) == .deref) {
             obj_type_raw = try self.inferExpr(self.nodeData(obj_node).lhs);
@@ -1776,7 +1776,18 @@ const TypeChecker = struct {
             .index_access => try self.inferIndexAccess(node),
 
             .addr_of => blk: {
-                const operand_type = try self.inferExpr(self.nodeData(node).lhs);
+                const operand_node = self.nodeData(node).lhs;
+                if (operand_node != null_node and self.nodeTag(operand_node) == .field_access and
+                    try self.accessPathStartsFromConstRef(operand_node))
+                {
+                    const loc = self.tokenLoc(self.nodeMainToken(node));
+                    try self.diagnostics.addError(
+                        loc.start,
+                        loc.end,
+                        "cannot take mutable address of field of read-only reference",
+                    );
+                }
+                const operand_type = try self.inferExpr(operand_node);
                 if (operand_type == types.null_type) break :blk types.null_type;
                 break :blk try self.type_pool.intern(self.allocator, .{ .ptr_type = .{ .pointee = operand_type, .is_const = false } });
             },
@@ -1956,7 +1967,7 @@ const TypeChecker = struct {
                             // Check mutability: if calling through @T (const ptr),
                             // the method must not require &T (mutable) receiver.
                             if (method_type_id != types.null_type) {
-                                try self.checkMethodMutability(method_sym, obj_type_raw, method_name, node);
+                                try self.checkMethodMutability(method_sym, obj_type_raw, fa_data.lhs, method_name, node);
                             }
 
                             if (method_type_id != types.null_type) {
@@ -2492,17 +2503,13 @@ const TypeChecker = struct {
         self: *TypeChecker,
         method_sym: Symbol,
         obj_type_raw: TypeId,
+        obj_node: NodeIndex,
         method_name: []const u8,
         call_node: NodeIndex,
     ) CheckError!void {
         // Check if the object is accessed through a const pointer (@T).
-        const is_const_ref = blk: {
-            const obj_resolved = self.type_pool.get(obj_type_raw);
-            break :blk switch (obj_resolved) {
-                .ptr_type => |pt| pt.is_const,
-                else => false,
-            };
-        };
+        const is_const_ref = self.isConstPointerType(obj_type_raw) or
+            try self.accessPathStartsFromConstRef(obj_node);
 
         if (!is_const_ref) return;
 
@@ -2531,6 +2538,33 @@ const TypeChecker = struct {
                 .{method_name},
             );
         }
+    }
+
+    fn isConstPointerType(self: *const TypeChecker, type_id: TypeId) bool {
+        if (type_id == types.null_type or type_id < types.primitives.count) return false;
+        return switch (self.type_pool.get(type_id)) {
+            .ptr_type => |pt| pt.is_const,
+            else => false,
+        };
+    }
+
+    fn accessPathStartsFromConstRef(self: *TypeChecker, node: NodeIndex) CheckError!bool {
+        if (node == null_node) return false;
+        return switch (self.nodeTag(node)) {
+            .ident => blk: {
+                if (self.resolution_map[node]) |sym_id| {
+                    break :blk self.isConstPointerType(self.symbols.getSymbol(sym_id).type_id);
+                }
+                break :blk false;
+            },
+            .field_access => blk: {
+                const base = self.nodeData(node).lhs;
+                if (try self.accessPathStartsFromConstRef(base)) break :blk true;
+                break :blk self.isConstPointerType(try self.inferExpr(base));
+            },
+            .deref => self.isConstPointerType(try self.inferExpr(self.nodeData(node).lhs)),
+            else => self.isConstPointerType(try self.inferExpr(node)),
+        };
     }
 
     fn inferIdent(self: *TypeChecker, node: NodeIndex) CheckError!TypeId {

--- a/tests/e2e/cases/err_struct_nested_const_ref_addr.run
+++ b/tests/e2e/cases/err_struct_nested_const_ref_addr.run
@@ -1,0 +1,23 @@
+// compile-error: cannot take mutable address of field of read-only reference
+package main
+
+pub type Inner struct {
+    value int
+}
+
+pub type Outer struct {
+    inner Inner
+}
+
+fun setValue(inner &Inner, value int) {
+    inner.value = value
+}
+
+fun update(outer @Outer) {
+    setValue(&outer.inner, 42)
+}
+
+pub fun main() {
+    outer := Outer{inner: Inner{value: 1}}
+    update(@outer)
+}

--- a/tests/e2e/cases/err_struct_nested_const_ref_assign.run
+++ b/tests/e2e/cases/err_struct_nested_const_ref_assign.run
@@ -1,0 +1,19 @@
+// compile-error: cannot assign to field of read-only reference
+package main
+
+pub type Inner struct {
+    value int
+}
+
+pub type Outer struct {
+    inner Inner
+}
+
+fun setValue(outer @Outer) {
+    outer.inner.value = 2
+}
+
+pub fun main() {
+    outer := Outer{inner: Inner{value: 1}}
+    setValue(@outer)
+}

--- a/tests/e2e/cases/err_struct_nested_const_ref_method.run
+++ b/tests/e2e/cases/err_struct_nested_const_ref_method.run
@@ -1,0 +1,23 @@
+// compile-error: cannot call mutating method
+package main
+
+pub type Inner struct {
+    value int
+}
+
+fun (inner &Inner) inc() {
+    inner.value = inner.value + 1
+}
+
+pub type Outer struct {
+    inner Inner
+}
+
+fun bump(outer @Outer) {
+    outer.inner.inc()
+}
+
+pub fun main() {
+    outer := Outer{inner: Inner{value: 1}}
+    bump(@outer)
+}

--- a/tests/e2e/cases/struct_nested_field_addr.run
+++ b/tests/e2e/cases/struct_nested_field_addr.run
@@ -1,0 +1,22 @@
+// expect: 42
+package main
+
+use "fmt"
+
+pub type Inner struct {
+    value int
+}
+
+pub type Outer struct {
+    inner Inner
+}
+
+fun setValue(inner &Inner, value int) {
+    inner.value = value
+}
+
+pub fun main() {
+    outer := Outer{inner: Inner{value: 1}}
+    setValue(&outer.inner, 42)
+    fmt.println(outer.inner.value)
+}

--- a/tests/e2e/cases/struct_nested_field_assign.run
+++ b/tests/e2e/cases/struct_nested_field_assign.run
@@ -1,0 +1,20 @@
+// expect: 58
+package main
+
+use "fmt"
+
+pub type Inner struct {
+    label int
+    value int
+}
+
+pub type Outer struct {
+    tag int
+    inner Inner
+}
+
+pub fun main() {
+    outer := Outer{tag: 9, inner: Inner{label: 7, value: 1}}
+    outer.inner.value = 42
+    fmt.println(outer.tag + outer.inner.label + outer.inner.value)
+}

--- a/tests/e2e/cases/struct_nested_field_ref_assign.run
+++ b/tests/e2e/cases/struct_nested_field_ref_assign.run
@@ -1,0 +1,22 @@
+// expect: 99
+package main
+
+use "fmt"
+
+pub type Inner struct {
+    value int
+}
+
+pub type Outer struct {
+    inner Inner
+}
+
+fun (outer &Outer) setValue(value int) {
+    outer.inner.value = value
+}
+
+pub fun main() {
+    outer := Outer{inner: Inner{value: 1}}
+    outer.setValue(99)
+    fmt.println(outer.inner.value)
+}

--- a/tests/e2e/cases/struct_nested_method_mut.run
+++ b/tests/e2e/cases/struct_nested_method_mut.run
@@ -1,0 +1,22 @@
+// expect: 2
+package main
+
+use "fmt"
+
+pub type Inner struct {
+    value int
+}
+
+fun (inner &Inner) inc() {
+    inner.value = inner.value + 1
+}
+
+pub type Outer struct {
+    inner Inner
+}
+
+pub fun main() {
+    outer := Outer{inner: Inner{value: 1}}
+    outer.inner.inc()
+    fmt.println(outer.inner.value)
+}


### PR DESCRIPTION
## Summary
- Add field layout tracking in lowering so struct field addresses can be computed with offsets
- Lower field assignments, field addresses, and method calls through field access as lvalues
- Tighten type checking for mutable address-taking and method calls from const references
- Update Serena project metadata and project memories for current workspace conventions

## Testing
- Not run (not requested)